### PR TITLE
Add Crystal Rush tycoon gameplay systems

### DIFF
--- a/default.project.json
+++ b/default.project.json
@@ -1,0 +1,15 @@
+{
+  "name": "CrystalRushTycoon",
+  "tree": {
+    "$className": "DataModel",
+    "ReplicatedStorage": {
+      "$path": "src/ReplicatedStorage"
+    },
+    "ServerScriptService": {
+      "$path": "src/ServerScriptService"
+    },
+    "StarterPlayer": {
+      "$path": "src/StarterPlayer"
+    }
+  }
+}

--- a/src/ReplicatedStorage/Shared/Config.lua
+++ b/src/ReplicatedStorage/Shared/Config.lua
@@ -1,0 +1,213 @@
+local Config = {}
+
+Config.GameName = "Crystal Rush Tycoon"
+Config.ZoneSpacing = 220
+Config.ZoneY = 0
+Config.ZoneSize = Vector3.new(140, 1, 140)
+Config.BaseWalkSpeed = 14
+Config.TeleportPadSize = Vector3.new(10, 1, 10)
+Config.DepositPadSize = Vector3.new(14, 1, 14)
+Config.DepositPosition = Vector3.new(0, 0.6, -20)
+Config.OrbRespawnSeconds = 8
+Config.MaxOrbsPerZone = 40
+Config.InventoryTick = 0.25
+
+Config.Zones = {
+    {
+        Name = "Starter Meadow",
+        Description = "Collect shimmering shards and learn the basics.",
+        UnlockCost = 0,
+        OrbValue = 1,
+        OrbColor = Color3.fromRGB(83, 203, 255),
+        RareOrbValue = 8,
+        RareChance = 0.08,
+        OrbDensity = 26
+    },
+    {
+        Name = "Crystal Caves",
+        Description = "Hidden caverns with higher value finds.",
+        UnlockCost = 750,
+        OrbValue = 4,
+        OrbColor = Color3.fromRGB(255, 89, 89),
+        RareOrbValue = 30,
+        RareChance = 0.1,
+        OrbDensity = 28
+    },
+    {
+        Name = "Sunspire Desert",
+        Description = "Hot sands with frequent energy bursts.",
+        UnlockCost = 5200,
+        OrbValue = 12,
+        OrbColor = Color3.fromRGB(245, 205, 48),
+        RareOrbValue = 70,
+        RareChance = 0.12,
+        OrbDensity = 30
+    },
+    {
+        Name = "Storm Peaks",
+        Description = "Lightning-charged air produces volatile shards.",
+        UnlockCost = 18600,
+        OrbValue = 28,
+        OrbColor = Color3.fromRGB(124, 156, 255),
+        RareOrbValue = 140,
+        RareChance = 0.14,
+        OrbDensity = 32
+    },
+    {
+        Name = "Luminous Lagoon",
+        Description = "Bioluminescent waters with radiant energy.",
+        UnlockCost = 52800,
+        OrbValue = 60,
+        OrbColor = Color3.fromRGB(16, 252, 194),
+        RareOrbValue = 320,
+        RareChance = 0.16,
+        OrbDensity = 34
+    },
+    {
+        Name = "Galactic Rift",
+        Description = "Zero-gravity void with monumental shards.",
+        UnlockCost = 158000,
+        OrbValue = 140,
+        OrbColor = Color3.fromRGB(206, 44, 255),
+        RareOrbValue = 650,
+        RareChance = 0.18,
+        OrbDensity = 36
+    }
+}
+
+Config.Upgrades = {
+    Capacity = {
+        { Level = 1, Capacity = 20, Cost = 0 },
+        { Level = 2, Capacity = 40, Cost = 150 },
+        { Level = 3, Capacity = 75, Cost = 550 },
+        { Level = 4, Capacity = 120, Cost = 1800 },
+        { Level = 5, Capacity = 200, Cost = 5200 },
+        { Level = 6, Capacity = 320, Cost = 14800 },
+        { Level = 7, Capacity = 480, Cost = 42400 },
+        { Level = 8, Capacity = 720, Cost = 120000 }
+    },
+    Speed = {
+        { Level = 1, WalkSpeed = 14, Cost = 0 },
+        { Level = 2, WalkSpeed = 16, Cost = 400 },
+        { Level = 3, WalkSpeed = 18, Cost = 1600 },
+        { Level = 4, WalkSpeed = 20, Cost = 5200 },
+        { Level = 5, WalkSpeed = 22, Cost = 16800 },
+        { Level = 6, WalkSpeed = 24, Cost = 56000 }
+    },
+    Converter = {
+        { Level = 1, Multiplier = 1, Cost = 0 },
+        { Level = 2, Multiplier = 1.3, Cost = 950 },
+        { Level = 3, Multiplier = 1.6, Cost = 4400 },
+        { Level = 4, Multiplier = 2.1, Cost = 15600 },
+        { Level = 5, Multiplier = 2.8, Cost = 49800 },
+        { Level = 6, Multiplier = 3.6, Cost = 162000 }
+    }
+}
+
+Config.Rebirth = {
+    BaseCost = 325000,
+    CostMultiplier = 2.85,
+    RewardMultiplier = 1.75,
+    BonusEnergy = 3500
+}
+
+Config.Gamepasses = {
+    VIP = {
+        Name = "VIP Quantum Membership",
+        Benefit = "Permanent 2x deposit multiplier, golden name tag",
+        Price = 399,
+        Id = 0,
+        MultiplierBonus = 2
+    },
+    Speed = {
+        Name = "Hyper Sprint",
+        Benefit = "+6 WalkSpeed permanently",
+        Price = 149,
+        Id = 0,
+        ExtraSpeed = 6
+    },
+    InfiniteStorage = {
+        Name = "Infinite Storage",
+        Benefit = "Never run out of backpack space",
+        Price = 799,
+        Id = 0
+    },
+    LuckyAura = {
+        Name = "Lucky Aura",
+        Benefit = "50% more rare shards whenever you collect",
+        Price = 249,
+        Id = 0,
+        RareBonus = 0.5
+    },
+    AutoCollector = {
+        Name = "Auto Collector Drone",
+        Benefit = "Automatically vacuum nearby shards",
+        Price = 499,
+        Id = 0,
+        Radius = 14,
+        Interval = 1.5
+    }
+}
+
+Config.DeveloperProducts = {
+    EnergyPacks = {
+        { Key = "SmallPack", Name = "Pocketful of Energy", Amount = 800, Price = 49, Id = 0 },
+        { Key = "MediumPack", Name = "Crate of Energy", Amount = 2800, Price = 149, Id = 0 },
+        { Key = "LargePack", Name = "Truck of Energy", Amount = 9200, Price = 399, Id = 0 },
+        { Key = "UltraPack", Name = "Planetary Cache", Amount = 18500, Price = 799, Id = 0 }
+    },
+    Boosts = {
+        { Key = "TwoXMultiplier10", Name = "10 min 2x Converter", Duration = 600, Multiplier = 2, Price = 99, Id = 0 },
+        { Key = "TwoXMultiplier30", Name = "30 min 2x Converter", Duration = 1800, Multiplier = 2, Price = 249, Id = 0 }
+    }
+}
+
+Config.TutorialMessages = {
+    "Welcome to Crystal Rush! Collect glowing shards on the island to fill your backpack.",
+    "Step on the golden deposit pad at base to convert shards into Energy.",
+    "Spend Energy on upgrades for capacity, speed, and converter multiplier for faster runs.",
+    "Unlock new zones from the teleporter ring once you can afford them.",
+    "Rebirth after maxing zones to permanently multiply your earnings!"
+}
+
+function Config.getZone(index)
+    return Config.Zones[index]
+end
+
+function Config.getUpgradePath(upgradeType)
+    return Config.Upgrades[upgradeType]
+end
+
+function Config.getNextUpgradeCost(upgradeType, currentLevel)
+    local path = Config.Upgrades[upgradeType]
+    if not path then
+        return nil
+    end
+
+    local nextLevel = path[currentLevel + 1]
+    return nextLevel and nextLevel.Cost or nil
+end
+
+function Config.getUpgradeStats(upgradeType, level)
+    local path = Config.Upgrades[upgradeType]
+    if not path then
+        return nil
+    end
+
+    return path[level]
+end
+
+function Config.getZoneUnlockCost(index)
+    local zone = Config.Zones[index]
+    return zone and zone.UnlockCost or nil
+end
+
+function Config.getRebirthCost(rebirthCount)
+    return math.floor(Config.Rebirth.BaseCost * (Config.Rebirth.CostMultiplier ^ rebirthCount))
+end
+
+function Config.getRebirthMultiplier(rebirths)
+    return Config.Rebirth.RewardMultiplier ^ rebirths
+end
+
+return Config

--- a/src/ServerScriptService/GameInit.server.lua
+++ b/src/ServerScriptService/GameInit.server.lua
@@ -1,0 +1,275 @@
+local Players = game:GetService("Players")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Config = require(ReplicatedStorage:WaitForChild("Shared"):WaitForChild("Config"))
+
+local RemotesModule = require(script.Parent.Modules.Remotes)
+local MapBuilder = require(script.Parent.Modules.MapBuilder)
+local SessionService = require(script.Parent.Modules.SessionService)
+local Monetization = require(script.Parent.Modules.Monetization)
+local UpgradeService = require(script.Parent.Modules.UpgradeService)
+local OrbManager = require(script.Parent.Modules.OrbManager)
+
+local remotes = RemotesModule.get()
+local mapReferences = MapBuilder.build()
+
+local function createLeaderstats(player)
+    local folder = Instance.new("Folder")
+    folder.Name = "leaderstats"
+    folder.Parent = player
+
+    local energy = Instance.new("IntValue")
+    energy.Name = "Energy"
+    energy.Value = 0
+    energy.Parent = folder
+
+    local rebirths = Instance.new("IntValue")
+    rebirths.Name = "Rebirths"
+    rebirths.Value = 0
+    rebirths.Parent = folder
+
+    local zone = Instance.new("IntValue")
+    zone.Name = "Zone"
+    zone.Value = 1
+    zone.Parent = folder
+end
+
+local function updateLeaderstats(player, summary)
+    local leaderstats = player:FindFirstChild("leaderstats")
+    if not leaderstats then
+        return
+    end
+
+    local energy = leaderstats:FindFirstChild("Energy")
+    if energy then
+        energy.Value = summary.Energy
+    end
+
+    local rebirths = leaderstats:FindFirstChild("Rebirths")
+    if rebirths then
+        rebirths.Value = summary.Rebirths
+    end
+
+    local zone = leaderstats:FindFirstChild("Zone")
+    if zone then
+        zone.Value = summary.ZoneLevel
+    end
+end
+
+local function teleportPlayer(player, targetPosition)
+    local character = player.Character
+    if not character then
+        return
+    end
+
+    local root = character:FindFirstChild("HumanoidRootPart")
+    if not root then
+        return
+    end
+
+    root.CFrame = CFrame.new(targetPosition + Vector3.new(0, 4, 0))
+end
+
+local function sendState(player)
+    local summary = UpgradeService.GetStateSummary(player)
+    if not summary then
+        return
+    end
+
+    updateLeaderstats(player, summary)
+    remotes.StateUpdate:FireClient(player, summary)
+end
+
+UpgradeService.SetDependencies(remotes, Monetization)
+Monetization.SetStateUpdateCallback(sendState)
+Monetization.OnPassUnlocked(function(player, passKey)
+    if passKey == "Speed" then
+        task.defer(UpgradeService.ApplyCharacterScaling, player)
+    end
+
+    if passKey == "InfiniteStorage" or passKey == "VIP" or passKey == "LuckyAura" then
+        task.defer(sendState, player)
+    end
+end)
+
+Monetization.Init(remotes)
+OrbManager.Init(mapReferences, remotes, Monetization, sendState)
+
+local function handleDeposit(player)
+    local session = SessionService.GetSession(player)
+    if not session or session.Inventory <= 0 then
+        return
+    end
+
+    local now = os.clock()
+    local last = player:GetAttribute("LastDepositTime") or 0
+    if now - last < 0.6 then
+        return
+    end
+    player:SetAttribute("LastDepositTime", now)
+
+    local multiplier = UpgradeService.GetConverterMultiplier(player)
+    local amount = math.floor(session.Inventory * multiplier)
+    if amount <= 0 then
+        SessionService.SetInventory(player, 0)
+        return
+    end
+
+    SessionService.SetInventory(player, 0)
+    SessionService.AdjustEnergy(player, amount)
+    remotes.Notify:FireClient(player, string.format("Deposited for %d Energy", amount))
+    sendState(player)
+end
+
+local function onDepositTouched(part)
+    if not part or not part.Parent then
+        return
+    end
+
+    local player = Players:GetPlayerFromCharacter(part.Parent)
+    if not player then
+        return
+    end
+
+    handleDeposit(player)
+end
+
+local function bindTeleporters()
+    for index, pad in pairs(mapReferences.TeleporterPads) do
+        pad.Touched:Connect(function(part)
+            if not part or not part.Parent then
+                return
+            end
+
+            local player = Players:GetPlayerFromCharacter(part.Parent)
+            if not player then
+                return
+            end
+
+            local session = SessionService.GetSession(player)
+            if not session then
+                return
+            end
+
+            if session.Data.ZoneLevel < index then
+                local zoneConfig = Config.getZone(index)
+                if zoneConfig then
+                    remotes.Notify:FireClient(player, string.format("Unlock %s first!", zoneConfig.Name))
+                end
+                return
+            end
+
+            local zonePart = mapReferences.ZonePlatforms[index]
+            if zonePart then
+                teleportPlayer(player, zonePart.Position)
+            end
+        end)
+    end
+
+    for index, pad in pairs(mapReferences.ReturnPads) do
+        pad.Touched:Connect(function(part)
+            if not part or not part.Parent then
+                return
+            end
+
+            local player = Players:GetPlayerFromCharacter(part.Parent)
+            if not player then
+                return
+            end
+
+            local basePart = mapReferences.ZonePlatforms[1]
+            if basePart then
+                teleportPlayer(player, basePart.Position)
+            end
+        end)
+    end
+end
+
+mapReferences.DepositPad.Touched:Connect(onDepositTouched)
+bindTeleporters()
+
+local actionHandlers = {
+    UpgradeCapacity = function(player)
+        return UpgradeService.HandleUpgrade(player, "Capacity")
+    end,
+    UpgradeSpeed = function(player)
+        return UpgradeService.HandleUpgrade(player, "Speed")
+    end,
+    UpgradeConverter = function(player)
+        return UpgradeService.HandleUpgrade(player, "Converter")
+    end,
+    UnlockZone = function(player)
+        return UpgradeService.HandleZoneUnlock(player)
+    end,
+    Rebirth = function(player)
+        return UpgradeService.HandleRebirth(player)
+    end,
+    __REQUEST_STATE__ = function(player)
+        sendState(player)
+        return false
+    end
+}
+
+remotes.ActionRequest.OnServerEvent:Connect(function(player, action, payload)
+    if typeof(action) ~= "string" then
+        return
+    end
+
+    local handler = actionHandlers[action]
+    if not handler then
+        return
+    end
+
+    local success, message = handler(player, payload)
+    if message then
+        remotes.Notify:FireClient(player, message)
+    end
+
+    if success then
+        sendState(player)
+    end
+end)
+
+local function showTutorial(player)
+    for index, text in ipairs(Config.TutorialMessages) do
+        task.delay(3 + (index - 1) * 6, function()
+            if player.Parent then
+                remotes.Tutorial:FireClient(player, text)
+            end
+        end)
+    end
+end
+
+local function onCharacterAdded(player, character)
+    task.wait(0.2)
+    UpgradeService.ApplyCharacterScaling(player)
+end
+
+local function onPlayerAdded(player)
+    createLeaderstats(player)
+    local session = SessionService.CreateSession(player)
+
+    Monetization.RegisterPlayer(player)
+    Monetization.SyncSession(player)
+    OrbManager.RegisterPlayer(player)
+
+    player.CharacterAdded:Connect(function(character)
+        onCharacterAdded(player, character)
+    end)
+
+    if player.Character then
+        onCharacterAdded(player, player.Character)
+    end
+
+    sendState(player)
+    showTutorial(player)
+end
+
+Players.PlayerAdded:Connect(onPlayerAdded)
+Players.PlayerRemoving:Connect(function(player)
+    Monetization.CleanupPlayer(player)
+    OrbManager.UnregisterPlayer(player)
+end)
+
+for _, player in ipairs(Players:GetPlayers()) do
+    onPlayerAdded(player)
+end

--- a/src/ServerScriptService/Modules/MapBuilder.lua
+++ b/src/ServerScriptService/Modules/MapBuilder.lua
@@ -1,0 +1,182 @@
+local Workspace = game:GetService("Workspace")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local Config = require(ReplicatedStorage:WaitForChild("Shared"):WaitForChild("Config"))
+
+local MapBuilder = {}
+
+local function createBillboard(parent, title, description)
+    local billboard = Instance.new("BillboardGui")
+    billboard.Name = "Billboard"
+    billboard.AlwaysOnTop = true
+    billboard.Size = UDim2.new(8, 0, 3, 0)
+    billboard.ExtentsOffset = Vector3.new(0, 6, 0)
+    billboard.Parent = parent
+
+    local titleLabel = Instance.new("TextLabel")
+    titleLabel.BackgroundTransparency = 1
+    titleLabel.Text = title
+    titleLabel.Font = Enum.Font.GothamBold
+    titleLabel.TextScaled = true
+    titleLabel.TextColor3 = Color3.fromRGB(255, 255, 255)
+    titleLabel.Size = UDim2.new(1, 0, 0.6, 0)
+    titleLabel.Position = UDim2.new(0, 0, 0, 0)
+    titleLabel.Parent = billboard
+
+    local descLabel = Instance.new("TextLabel")
+    descLabel.BackgroundTransparency = 1
+    descLabel.TextWrapped = true
+    descLabel.Text = description
+    descLabel.Font = Enum.Font.Gotham
+    descLabel.TextScaled = true
+    descLabel.TextColor3 = Color3.fromRGB(213, 233, 255)
+    descLabel.Size = UDim2.new(1, 0, 0.4, 0)
+    descLabel.Position = UDim2.new(0, 0, 0.6, 0)
+    descLabel.Parent = billboard
+
+    return billboard
+end
+
+function MapBuilder.build()
+    local existing = Workspace:FindFirstChild("GeneratedMap")
+    if existing then
+        existing:Destroy()
+    end
+
+    local mapFolder = Instance.new("Folder")
+    mapFolder.Name = "GeneratedMap"
+    mapFolder.Parent = Workspace
+
+    local zonesFolder = Instance.new("Folder")
+    zonesFolder.Name = "Zones"
+    zonesFolder.Parent = mapFolder
+
+    local teleporterFolder = Instance.new("Folder")
+    teleporterFolder.Name = "TeleportPads"
+    teleporterFolder.Parent = mapFolder
+
+    local basePlatform = Instance.new("Part")
+    basePlatform.Name = "BasePlatform"
+    basePlatform.Size = Config.ZoneSize
+    basePlatform.Position = Vector3.new(0, Config.ZoneY, 0)
+    basePlatform.Anchored = true
+    basePlatform.Material = Enum.Material.Grass
+    basePlatform.Color = Color3.fromRGB(51, 120, 51)
+    basePlatform.Parent = mapFolder
+
+    local spawnLocation = Instance.new("SpawnLocation")
+    spawnLocation.Name = "Spawn"
+    spawnLocation.Size = Vector3.new(8, 1, 8)
+    spawnLocation.Position = basePlatform.Position + Vector3.new(0, 1.05, 0)
+    spawnLocation.Anchored = true
+    spawnLocation.Neutral = true
+    spawnLocation.Transparency = 1
+    spawnLocation.CanCollide = false
+    spawnLocation.Parent = mapFolder
+
+    local depositPad = Instance.new("Part")
+    depositPad.Name = "DepositPad"
+    depositPad.Size = Config.DepositPadSize
+    depositPad.Position = Config.DepositPosition
+    depositPad.Anchored = true
+    depositPad.Material = Enum.Material.Neon
+    depositPad.Color = Color3.fromRGB(255, 215, 79)
+    depositPad.TopSurface = Enum.SurfaceType.Smooth
+    depositPad.BottomSurface = Enum.SurfaceType.Smooth
+    depositPad.Parent = mapFolder
+
+    createBillboard(depositPad, "Deposit", "Convert shards into Energy here")
+
+    local upgradePedestal = Instance.new("Part")
+    upgradePedestal.Name = "UpgradePedestal"
+    upgradePedestal.Size = Vector3.new(12, 1, 12)
+    upgradePedestal.Position = basePlatform.Position + Vector3.new(0, 0.6, 20)
+    upgradePedestal.Anchored = true
+    upgradePedestal.Material = Enum.Material.Metal
+    upgradePedestal.Color = Color3.fromRGB(93, 93, 131)
+    upgradePedestal.Parent = mapFolder
+
+    createBillboard(upgradePedestal, "Upgrades", "Use the UI to purchase upgrades")
+
+    local teleporterRing = Instance.new("Part")
+    teleporterRing.Name = "TeleporterRing"
+    teleporterRing.Size = Vector3.new(70, 1, 70)
+    teleporterRing.Position = basePlatform.Position + Vector3.new(0, 0.6, 0)
+    teleporterRing.Anchored = true
+    teleporterRing.Transparency = 0.6
+    teleporterRing.Color = Color3.fromRGB(137, 155, 255)
+    teleporterRing.Material = Enum.Material.ForceField
+    teleporterRing.Parent = mapFolder
+
+    local teleporterPads = {}
+    local returnPads = {}
+    local zonePlatforms = {}
+    local orbContainers = {}
+
+    for index, zoneConfig in ipairs(Config.Zones) do
+        local zoneFolder = Instance.new("Folder")
+        zoneFolder.Name = string.format("Zone_%d", index)
+        zoneFolder.Parent = zonesFolder
+
+        local zonePart
+        if index == 1 then
+            zonePart = basePlatform
+        else
+            zonePart = Instance.new("Part")
+            zonePart.Name = zoneConfig.Name:gsub(" ", "") .. "Platform"
+            zonePart.Size = Config.ZoneSize
+            zonePart.Position = Vector3.new((index - 1) * Config.ZoneSpacing, Config.ZoneY, 0)
+            zonePart.Anchored = true
+            zonePart.Material = Enum.Material.SmoothPlastic
+            zonePart.Color = zoneConfig.OrbColor:lerp(Color3.fromRGB(40, 40, 40), 0.5)
+            zonePart.Parent = zoneFolder
+        end
+        zonePlatforms[index] = zonePart
+
+        local orbFolder = Instance.new("Folder")
+        orbFolder.Name = "Orbs"
+        orbFolder.Parent = zoneFolder
+        orbContainers[index] = orbFolder
+
+        if index > 1 then
+            local portal = Instance.new("Part")
+            portal.Name = zoneConfig.Name:gsub(" ", "") .. "Portal"
+            portal.Size = Config.TeleportPadSize
+            portal.Anchored = true
+            portal.CanCollide = false
+            portal.Material = Enum.Material.Neon
+            portal.Color = zoneConfig.OrbColor
+            local angle = math.rad((index - 2) * (360 / math.max(1, (#Config.Zones - 1))))
+            local radius = 32
+            portal.Position = teleporterRing.Position + Vector3.new(math.cos(angle) * radius, 0.6, math.sin(angle) * radius)
+            portal.Parent = teleporterFolder
+            createBillboard(portal, zoneConfig.Name, string.format("Unlock for %d Energy", zoneConfig.UnlockCost))
+            teleporterPads[index] = portal
+        end
+
+        local returnPad = Instance.new("Part")
+        returnPad.Name = zoneConfig.Name:gsub(" ", "") .. "ReturnPad"
+        returnPad.Size = Config.TeleportPadSize
+        local offsetX = -Config.ZoneSize.X / 2 + 14
+        local offsetZ = Config.ZoneSize.Z / 2 - 14
+        returnPad.Position = zonePart.Position + Vector3.new(offsetX, 0.6, offsetZ)
+        returnPad.Anchored = true
+        returnPad.CanCollide = false
+        returnPad.Material = Enum.Material.Neon
+        returnPad.Color = Color3.fromRGB(255, 255, 255)
+        returnPad.Parent = zoneFolder
+        createBillboard(returnPad, "Return", "Step to teleport back")
+        returnPads[index] = returnPad
+    end
+
+    return {
+        MapFolder = mapFolder,
+        DepositPad = depositPad,
+        TeleporterPads = teleporterPads,
+        ReturnPads = returnPads,
+        ZonePlatforms = zonePlatforms,
+        OrbContainers = orbContainers
+    }
+end
+
+return MapBuilder

--- a/src/ServerScriptService/Modules/Monetization.lua
+++ b/src/ServerScriptService/Modules/Monetization.lua
@@ -1,0 +1,226 @@
+local Players = game:GetService("Players")
+local MarketplaceService = game:GetService("MarketplaceService")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local Config = require(ReplicatedStorage:WaitForChild("Shared"):WaitForChild("Config"))
+local SessionService = require(script.Parent:WaitForChild("SessionService"))
+
+local Monetization = {}
+
+local remotes = nil
+local stateUpdateCallback = nil
+
+local passOwnership = {}
+local passLookupById = {}
+local productLookupById = {}
+local productLookupByKey = {}
+
+local passUnlockedCallbacks = {}
+
+local function buildLookups()
+    passLookupById = {}
+    productLookupById = {}
+    productLookupByKey = {}
+
+    for key, passInfo in pairs(Config.Gamepasses) do
+        if passInfo.Id and passInfo.Id > 0 then
+            passLookupById[passInfo.Id] = key
+        end
+    end
+
+    for categoryName, items in pairs(Config.DeveloperProducts) do
+        for _, info in ipairs(items) do
+            local entry = { Category = categoryName, Info = info }
+            productLookupByKey[info.Key] = entry
+            if info.Id and info.Id > 0 then
+                productLookupById[info.Id] = entry
+            end
+        end
+    end
+end
+
+local function notify(player, message)
+    if remotes and remotes.Notify then
+        remotes.Notify:FireClient(player, message)
+    end
+end
+
+local function updateState(player)
+    if stateUpdateCallback then
+        stateUpdateCallback(player)
+    end
+end
+
+local function setPass(player, key, value, suppressFeedback)
+    passOwnership[player] = passOwnership[player] or {}
+    passOwnership[player][key] = value or nil
+
+    local session = SessionService.GetSession(player)
+    if session then
+        session.OwnedGamepasses = session.OwnedGamepasses or {}
+        session.OwnedGamepasses[key] = value and true or nil
+    end
+
+    player:SetAttribute("Gamepass_" .. key, value and true or false)
+
+    if value then
+        if not suppressFeedback then
+            notify(player, string.format("%s unlocked!", Config.Gamepasses[key].Name))
+        end
+
+        for _, callback in ipairs(passUnlockedCallbacks) do
+            task.defer(callback, player, key)
+        end
+    end
+
+    if not suppressFeedback then
+        updateState(player)
+    end
+end
+
+function Monetization.SetRemotes(remoteTable)
+    remotes = remoteTable
+    buildLookups()
+end
+
+function Monetization.SetStateUpdateCallback(callback)
+    stateUpdateCallback = callback
+end
+
+function Monetization.OnPassUnlocked(callback)
+    table.insert(passUnlockedCallbacks, callback)
+end
+
+function Monetization.PlayerHasPass(player, key)
+    local owned = passOwnership[player]
+    return owned and owned[key] == true or false
+end
+
+function Monetization.GetOwnedPasses(player)
+    return passOwnership[player] or {}
+end
+
+function Monetization.RegisterPlayer(player)
+    passOwnership[player] = passOwnership[player] or {}
+    local session = SessionService.GetSession(player)
+    if session then
+        session.OwnedGamepasses = session.OwnedGamepasses or {}
+    end
+
+    for key, info in pairs(Config.Gamepasses) do
+        if info.Id and info.Id > 0 then
+            local success, owns = pcall(MarketplaceService.UserOwnsGamePassAsync, MarketplaceService, player.UserId, info.Id)
+            if success and owns then
+                setPass(player, key, true, true)
+            end
+        end
+    end
+
+    updateState(player)
+end
+
+function Monetization.SyncSession(player)
+    local session = SessionService.GetSession(player)
+    if not session then
+        return
+    end
+
+    session.OwnedGamepasses = session.OwnedGamepasses or {}
+    local owned = passOwnership[player]
+    if owned then
+        for key, value in pairs(owned) do
+            if value then
+                session.OwnedGamepasses[key] = true
+            end
+        end
+    end
+end
+
+function Monetization.CleanupPlayer(player)
+    passOwnership[player] = nil
+end
+
+local function handlePurchaseRequest(player, payload)
+    if typeof(payload) ~= "table" then
+        return
+    end
+
+    local requestType = payload.Type
+    if requestType == "Gamepass" then
+        local passKey = payload.Key
+        local info = Config.Gamepasses[passKey]
+        if info and info.Id and info.Id > 0 then
+            MarketplaceService:PromptGamePassPurchase(player, info.Id)
+        else
+            notify(player, "Gamepass ID not set yet.")
+        end
+    elseif requestType == "Product" then
+        local productKey = payload.Key
+        local entry = productLookupByKey[productKey]
+        if entry and entry.Info.Id and entry.Info.Id > 0 then
+            MarketplaceService:PromptProductPurchase(player, entry.Info.Id)
+        else
+            notify(player, "Product ID not set yet.")
+        end
+    end
+end
+
+local function awardProduct(player, entry)
+    local session = SessionService.GetSession(player)
+    if not session then
+        return Enum.ProductPurchaseDecision.NotProcessedYet
+    end
+
+    local info = entry.Info
+    if entry.Category == "EnergyPacks" then
+        SessionService.AdjustEnergy(player, info.Amount)
+        notify(player, string.format("+%d Energy!", info.Amount))
+        updateState(player)
+    elseif entry.Category == "Boosts" then
+        local expiresAt = os.time() + info.Duration
+        SessionService.AddBoost(player, info.Key, { Multiplier = info.Multiplier, Expires = expiresAt })
+        notify(player, string.format("%s activated!", info.Name))
+        updateState(player)
+    end
+
+    return Enum.ProductPurchaseDecision.PurchaseGranted
+end
+
+local function processReceipt(receiptInfo)
+    local player = Players:GetPlayerByUserId(receiptInfo.PlayerId)
+    if not player then
+        return Enum.ProductPurchaseDecision.NotProcessedYet
+    end
+
+    local entry = productLookupById[receiptInfo.ProductId]
+    if not entry then
+        return Enum.ProductPurchaseDecision.NotProcessedYet
+    end
+
+    return awardProduct(player, entry)
+end
+
+local function onGamePassFinished(player, gamePassId, wasPurchased)
+    if not wasPurchased then
+        return
+    end
+
+    local passKey = passLookupById[gamePassId]
+    if passKey then
+        setPass(player, passKey, true)
+    end
+end
+
+function Monetization.Init(remoteTable)
+    Monetization.SetRemotes(remoteTable)
+
+    if not remotes then
+        return
+    end
+
+    remotes.PurchaseRequest.OnServerEvent:Connect(handlePurchaseRequest)
+    MarketplaceService.ProcessReceipt = processReceipt
+    MarketplaceService.PromptGamePassPurchaseFinished:Connect(onGamePassFinished)
+end
+
+return Monetization

--- a/src/ServerScriptService/Modules/OrbManager.lua
+++ b/src/ServerScriptService/Modules/OrbManager.lua
@@ -1,0 +1,251 @@
+local Players = game:GetService("Players")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local Config = require(ReplicatedStorage:WaitForChild("Shared"):WaitForChild("Config"))
+local SessionService = require(script.Parent:WaitForChild("SessionService"))
+local UpgradeService = require(script.Parent:WaitForChild("UpgradeService"))
+
+local OrbManager = {}
+
+local remotes
+local mapReferences
+local monetization
+local stateUpdateCallback
+
+local activeOrbs = {}
+local spawnThreads = {}
+local autoCollectorThreads = {}
+
+local function fireStateUpdate(player)
+    if stateUpdateCallback then
+        stateUpdateCallback(player)
+    end
+end
+
+local function randomOrbPosition(zonePart)
+    local size = zonePart.Size
+    local margin = 8
+    local xRange = math.max(4, size.X - margin)
+    local zRange = math.max(4, size.Z - margin)
+    local offsetX = (math.random() - 0.5) * xRange
+    local offsetZ = (math.random() - 0.5) * zRange
+    return zonePart.Position + Vector3.new(offsetX, 3, offsetZ)
+end
+
+local function markOrbDestroyed(zoneIndex, orb)
+    if activeOrbs[zoneIndex] then
+        activeOrbs[zoneIndex][orb] = nil
+    end
+end
+
+local function destroyOrb(zoneIndex, orb)
+    markOrbDestroyed(zoneIndex, orb)
+    if orb and orb.Parent then
+        orb:Destroy()
+    end
+end
+
+local function collectOrb(player, orb)
+    if not orb or not orb.Parent then
+        return
+    end
+
+    local zoneIndex = orb:GetAttribute("ZoneIndex")
+    local value = orb:GetAttribute("Value") or 1
+    local isRare = orb:GetAttribute("IsRare") == true
+
+    local session = SessionService.GetSession(player)
+    if not session then
+        return
+    end
+
+    if session.Data.ZoneLevel < zoneIndex then
+        return
+    end
+
+    local capacity = UpgradeService.GetCapacity(player)
+    if capacity ~= math.huge and session.Inventory + value > capacity then
+        return
+    end
+
+    if isRare and monetization and monetization.PlayerHasPass(player, "LuckyAura") then
+        value = math.floor(value * (1 + Config.Gamepasses.LuckyAura.RareBonus))
+    end
+
+    orb:SetAttribute("Collected", true)
+    destroyOrb(zoneIndex, orb)
+
+    SessionService.AddInventory(player, value)
+    fireStateUpdate(player)
+end
+
+local function onOrbTouched(orb, otherPart)
+    if orb:GetAttribute("Collected") then
+        return
+    end
+
+    local character = otherPart.Parent
+    if not character then
+        return
+    end
+
+    local player = Players:GetPlayerFromCharacter(character)
+    if not player then
+        return
+    end
+
+    collectOrb(player, orb)
+end
+
+local function spawnOrbInZone(zoneIndex)
+    local zonePart = mapReferences.ZonePlatforms[zoneIndex]
+    local container = mapReferences.OrbContainers[zoneIndex]
+    local zoneConfig = Config.getZone(zoneIndex)
+
+    if not zonePart or not container or not zoneConfig then
+        return
+    end
+
+    local orb = Instance.new("Part")
+    orb.Name = "EnergyOrb"
+    orb.Shape = Enum.PartType.Ball
+    orb.Size = Vector3.new(2.6, 2.6, 2.6)
+    orb.Material = Enum.Material.Neon
+    orb.Color = zoneConfig.OrbColor
+    orb.Anchored = true
+    orb.CanCollide = false
+    orb.Position = randomOrbPosition(zonePart)
+
+    local isRare = math.random() < zoneConfig.RareChance
+    local value = zoneConfig.OrbValue
+    if isRare then
+        value = zoneConfig.RareOrbValue
+        orb.Color = zoneConfig.OrbColor:lerp(Color3.fromRGB(255, 255, 255), 0.35)
+        local light = Instance.new("PointLight")
+        light.Color = orb.Color
+        light.Brightness = 2
+        light.Range = 12
+        light.Parent = orb
+    end
+
+    orb:SetAttribute("ZoneIndex", zoneIndex)
+    orb:SetAttribute("Value", value)
+    orb:SetAttribute("IsRare", isRare)
+
+    orb.Touched:Connect(function(part)
+        onOrbTouched(orb, part)
+    end)
+
+    orb.Parent = container
+    activeOrbs[zoneIndex] = activeOrbs[zoneIndex] or {}
+    activeOrbs[zoneIndex][orb] = true
+end
+
+local function maintainZone(zoneIndex)
+    spawnThreads[zoneIndex] = task.spawn(function()
+        local zoneConfig = Config.getZone(zoneIndex)
+        if not zoneConfig then
+            return
+        end
+
+        local target = math.min(zoneConfig.OrbDensity, Config.MaxOrbsPerZone)
+        while true do
+            local container = mapReferences.OrbContainers[zoneIndex]
+            if not container then
+                break
+            end
+
+            local existing = #container:GetChildren()
+            if existing < target then
+                spawnOrbInZone(zoneIndex)
+            end
+
+            task.wait(Config.OrbRespawnSeconds + math.random())
+        end
+    end)
+end
+
+local function stopAutoCollector(player)
+    local thread = autoCollectorThreads[player]
+    if thread then
+        thread.cancelled = true
+        autoCollectorThreads[player] = nil
+    end
+end
+
+local function runAutoCollector(player)
+    stopAutoCollector(player)
+
+    autoCollectorThreads[player] = {}
+    local threadRef = autoCollectorThreads[player]
+
+    task.spawn(function()
+        local settings = Config.Gamepasses.AutoCollector
+        while threadRef and not threadRef.cancelled do
+            if not monetization or not monetization.PlayerHasPass(player, "AutoCollector") then
+                break
+            end
+
+            local character = player.Character
+            local root = character and character:FindFirstChild("HumanoidRootPart")
+            if root then
+                local radius = settings and settings.Radius or 12
+                for zoneIndex, orbs in pairs(activeOrbs) do
+                    for orb in pairs(orbs) do
+                        if orb.Parent and not orb:GetAttribute("Collected") then
+                            local distance = (orb.Position - root.Position).Magnitude
+                            if distance <= radius then
+                                collectOrb(player, orb)
+                            end
+                        end
+                    end
+                end
+            end
+
+            local interval = settings and settings.Interval or 2
+            task.wait(interval)
+        end
+        autoCollectorThreads[player] = nil
+    end)
+end
+
+local function ensureAutoCollector(player)
+    if monetization and monetization.PlayerHasPass(player, "AutoCollector") then
+        runAutoCollector(player)
+    else
+        stopAutoCollector(player)
+    end
+end
+
+function OrbManager.Init(mapRefs, remoteTable, monetizationModule, updateCallback)
+    mapReferences = mapRefs
+    remotes = remoteTable
+    monetization = monetizationModule
+    stateUpdateCallback = updateCallback
+
+    if monetization and monetization.OnPassUnlocked then
+        monetization.OnPassUnlocked(function(player, passKey)
+            if passKey == "AutoCollector" then
+                task.defer(ensureAutoCollector, player)
+            end
+        end)
+    end
+
+    for index in ipairs(Config.Zones) do
+        maintainZone(index)
+    end
+end
+
+function OrbManager.RegisterPlayer(player)
+    ensureAutoCollector(player)
+
+    player.CharacterAdded:Connect(function()
+        task.defer(ensureAutoCollector, player)
+    end)
+end
+
+function OrbManager.UnregisterPlayer(player)
+    stopAutoCollector(player)
+end
+
+return OrbManager

--- a/src/ServerScriptService/Modules/Remotes.lua
+++ b/src/ServerScriptService/Modules/Remotes.lua
@@ -1,0 +1,42 @@
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local Remotes = {}
+
+local function getOrCreateRemote(folder, className, name)
+    local remote = folder:FindFirstChild(name)
+    if not remote then
+        remote = Instance.new(className)
+        remote.Name = name
+        remote.Parent = folder
+    end
+
+    return remote
+end
+
+function Remotes.get()
+    local container = ReplicatedStorage:FindFirstChild("Remotes")
+    if not container then
+        container = Instance.new("Folder")
+        container.Name = "Remotes"
+        container.Parent = ReplicatedStorage
+    end
+
+    local eventsFolder = container:FindFirstChild("Events")
+    if not eventsFolder then
+        eventsFolder = Instance.new("Folder")
+        eventsFolder.Name = "Events"
+        eventsFolder.Parent = container
+    end
+
+    local remotes = {
+        StateUpdate = getOrCreateRemote(eventsFolder, "RemoteEvent", "StateUpdate"),
+        Notify = getOrCreateRemote(eventsFolder, "RemoteEvent", "Notify"),
+        ActionRequest = getOrCreateRemote(eventsFolder, "RemoteEvent", "ActionRequest"),
+        PurchaseRequest = getOrCreateRemote(eventsFolder, "RemoteEvent", "PurchaseRequest"),
+        Tutorial = getOrCreateRemote(eventsFolder, "RemoteEvent", "Tutorial")
+    }
+
+    return remotes
+end
+
+return Remotes

--- a/src/ServerScriptService/Modules/SessionService.lua
+++ b/src/ServerScriptService/Modules/SessionService.lua
@@ -1,0 +1,243 @@
+local DataStoreService = game:GetService("DataStoreService")
+local Players = game:GetService("Players")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local Config = require(ReplicatedStorage:WaitForChild("Shared"):WaitForChild("Config"))
+
+local SessionService = {}
+
+local DATASTORE_NAME = "CrystalRush_PlayerData_V1"
+local dataStore = DataStoreService:GetDataStore(DATASTORE_NAME)
+
+local DEFAULT_DATA = {
+    Energy = 0,
+    TotalEnergy = 0,
+    CapacityLevel = 1,
+    SpeedLevel = 1,
+    ConverterLevel = 1,
+    ZoneLevel = 1,
+    Rebirths = 0,
+    Settings = {},
+    TutorialStep = 0
+}
+
+local sessions = {}
+
+local function deepCopy(original)
+    local copy = {}
+    for key, value in pairs(original) do
+        if typeof(value) == "table" then
+            copy[key] = deepCopy(value)
+        else
+            copy[key] = value
+        end
+    end
+    return copy
+end
+
+local function createDefaultData()
+    return deepCopy(DEFAULT_DATA)
+end
+
+local function getKey(player)
+    return string.format("Player_%d", player.UserId)
+end
+
+function SessionService.GetSession(player)
+    return sessions[player]
+end
+
+function SessionService.GetData(player)
+    local session = sessions[player]
+    return session and session.Data
+end
+
+local function loadData(player)
+    local key = getKey(player)
+    local success, stored = pcall(function()
+        return dataStore:GetAsync(key)
+    end)
+
+    if success and stored then
+        local newData = createDefaultData()
+        for k, v in pairs(stored) do
+            if newData[k] ~= nil then
+                if typeof(newData[k]) == "table" and typeof(v) == "table" then
+                    newData[k] = deepCopy(v)
+                else
+                    newData[k] = v
+                end
+            end
+        end
+        return newData
+    end
+
+    if not success then
+        warn("[SessionService] Failed to load data for", player.Name, stored)
+    end
+
+    return createDefaultData()
+end
+
+function SessionService.CreateSession(player)
+    local data = loadData(player)
+
+    local session = {
+        Player = player,
+        Data = data,
+        Inventory = 0,
+        Boosts = {},
+        OwnedGamepasses = {},
+        LastSave = os.time(),
+        LastDeposit = 0
+    }
+
+    sessions[player] = session
+    return session
+end
+
+local function serializeData(data)
+    local serialized = {}
+    for k, v in pairs(data) do
+        if typeof(v) == "table" then
+            serialized[k] = deepCopy(v)
+        else
+            serialized[k] = v
+        end
+    end
+    return serialized
+end
+
+function SessionService.SaveSession(player)
+    local session = sessions[player]
+    if not session then
+        return
+    end
+
+    local key = getKey(player)
+    local serialized = serializeData(session.Data)
+
+    local success, err = pcall(function()
+        dataStore:SetAsync(key, serialized)
+    end)
+
+    if not success then
+        warn("[SessionService] Failed to save data for", player.Name, err)
+    else
+        session.LastSave = os.time()
+    end
+end
+
+function SessionService.RemoveSession(player)
+    sessions[player] = nil
+end
+
+function SessionService.AdjustEnergy(player, delta)
+    local session = sessions[player]
+    if not session then
+        return 0
+    end
+
+    session.Data.Energy = math.max(0, session.Data.Energy + delta)
+    if delta > 0 then
+        session.Data.TotalEnergy = session.Data.TotalEnergy + delta
+    end
+    return session.Data.Energy
+end
+
+function SessionService.SetInventory(player, amount)
+    local session = sessions[player]
+    if not session then
+        return 0
+    end
+    session.Inventory = math.max(0, amount)
+    return session.Inventory
+end
+
+function SessionService.AddInventory(player, delta)
+    local session = sessions[player]
+    if not session then
+        return 0
+    end
+    session.Inventory = math.max(0, session.Inventory + delta)
+    return session.Inventory
+end
+
+function SessionService.RecordZoneUnlock(player, zoneLevel)
+    local session = sessions[player]
+    if not session then
+        return
+    end
+    session.Data.ZoneLevel = math.max(session.Data.ZoneLevel, zoneLevel)
+end
+
+function SessionService.RecordUpgrade(player, upgradeType, newLevel)
+    local session = sessions[player]
+    if not session then
+        return
+    end
+    local key = upgradeType .. "Level"
+    if session.Data[key] ~= nil then
+        session.Data[key] = newLevel
+    end
+end
+
+function SessionService.RecordRebirth(player)
+    local session = sessions[player]
+    if not session then
+        return
+    end
+    session.Data.Rebirths += 1
+    session.Data.Energy = Config.Rebirth.BonusEnergy
+    session.Data.TotalEnergy = session.Data.TotalEnergy + Config.Rebirth.BonusEnergy
+    session.Data.CapacityLevel = 1
+    session.Data.SpeedLevel = 1
+    session.Data.ConverterLevel = 1
+    session.Data.ZoneLevel = 1
+    session.Inventory = 0
+end
+
+function SessionService.AddBoost(player, key, data)
+    local session = sessions[player]
+    if not session then
+        return
+    end
+    session.Boosts[key] = data
+end
+
+function SessionService.GetBoosts(player)
+    local session = sessions[player]
+    if not session then
+        return {}
+    end
+    return session.Boosts
+end
+
+function SessionService.ClearBoost(player, key)
+    local session = sessions[player]
+    if not session then
+        return
+    end
+    session.Boosts[key] = nil
+end
+
+function SessionService.GetAllSessions()
+    return sessions
+end
+
+function SessionService.SaveAll()
+    for player in pairs(sessions) do
+        SessionService.SaveSession(player)
+    end
+end
+
+Players.PlayerRemoving:Connect(function(player)
+    SessionService.SaveSession(player)
+    SessionService.RemoveSession(player)
+end)
+
+game:BindToClose(function()
+    SessionService.SaveAll()
+end)
+
+return SessionService

--- a/src/ServerScriptService/Modules/UpgradeService.lua
+++ b/src/ServerScriptService/Modules/UpgradeService.lua
@@ -1,0 +1,245 @@
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local Config = require(ReplicatedStorage:WaitForChild("Shared"):WaitForChild("Config"))
+local SessionService = require(script.Parent:WaitForChild("SessionService"))
+
+local UpgradeService = {}
+
+UpgradeService.Monetization = nil
+UpgradeService.Remotes = nil
+
+local function getSession(player)
+    return SessionService.GetSession(player)
+end
+
+local function applyWalkSpeed(player)
+    local session = getSession(player)
+    if not session then
+        return
+    end
+
+    local character = player.Character
+    if not character then
+        return
+    end
+    local humanoid = character:FindFirstChildOfClass("Humanoid")
+    if not humanoid then
+        return
+    end
+
+    humanoid.WalkSpeed = UpgradeService.GetWalkSpeed(player)
+end
+
+local function cleanBoosts(session)
+    local now = os.time()
+    for key, data in pairs(session.Boosts) do
+        if data.Expires and data.Expires <= now then
+            session.Boosts[key] = nil
+        end
+    end
+end
+
+function UpgradeService.SetDependencies(remotes, monetization)
+    UpgradeService.Remotes = remotes
+    UpgradeService.Monetization = monetization
+end
+
+function UpgradeService.GetCapacity(player)
+    local session = getSession(player)
+    if not session then
+        return 0
+    end
+
+    local level = session.Data.CapacityLevel
+    local stats = Config.getUpgradeStats("Capacity", level)
+    local capacity = stats and stats.Capacity or 0
+
+    if UpgradeService.Monetization and UpgradeService.Monetization.PlayerHasPass(player, "InfiniteStorage") then
+        capacity = math.huge
+    end
+
+    return capacity
+end
+
+function UpgradeService.GetWalkSpeed(player)
+    local session = getSession(player)
+    if not session then
+        return Config.BaseWalkSpeed
+    end
+
+    local stats = Config.getUpgradeStats("Speed", session.Data.SpeedLevel)
+    local speed = stats and stats.WalkSpeed or Config.BaseWalkSpeed
+
+    if UpgradeService.Monetization and UpgradeService.Monetization.PlayerHasPass(player, "Speed") then
+        speed += Config.Gamepasses.Speed.ExtraSpeed
+    end
+
+    return speed
+end
+
+function UpgradeService.GetConverterMultiplier(player)
+    local session = getSession(player)
+    if not session then
+        return 1
+    end
+
+    cleanBoosts(session)
+
+    local stats = Config.getUpgradeStats("Converter", session.Data.ConverterLevel)
+    local multiplier = stats and stats.Multiplier or 1
+
+    if UpgradeService.Monetization and UpgradeService.Monetization.PlayerHasPass(player, "VIP") then
+        multiplier *= Config.Gamepasses.VIP.MultiplierBonus
+    end
+
+    local boosts = SessionService.GetBoosts(player)
+    for key, data in pairs(boosts) do
+        if data.Multiplier then
+            multiplier *= data.Multiplier
+        end
+    end
+
+    multiplier *= Config.getRebirthMultiplier(session.Data.Rebirths)
+
+    return multiplier
+end
+
+function UpgradeService.GetStateSummary(player)
+    local session = getSession(player)
+    if not session then
+        return nil
+    end
+
+    cleanBoosts(session)
+
+    local summary = {
+        Energy = session.Data.Energy,
+        TotalEnergy = session.Data.TotalEnergy,
+        Inventory = session.Inventory,
+        Capacity = UpgradeService.GetCapacity(player),
+        CapacityLevel = session.Data.CapacityLevel,
+        CapacityNextCost = Config.getNextUpgradeCost("Capacity", session.Data.CapacityLevel),
+        Speed = UpgradeService.GetWalkSpeed(player),
+        SpeedLevel = session.Data.SpeedLevel,
+        SpeedNextCost = Config.getNextUpgradeCost("Speed", session.Data.SpeedLevel),
+        ConverterLevel = session.Data.ConverterLevel,
+        ConverterMultiplier = UpgradeService.GetConverterMultiplier(player),
+        ConverterNextCost = Config.getNextUpgradeCost("Converter", session.Data.ConverterLevel),
+        ZoneLevel = session.Data.ZoneLevel,
+        NextZoneCost = Config.getZoneUnlockCost(session.Data.ZoneLevel + 1),
+        Rebirths = session.Data.Rebirths,
+        RebirthCost = Config.getRebirthCost(session.Data.Rebirths)
+    }
+
+    if summary.Capacity == math.huge then
+        summary.CapacityDisplay = "Infinite"
+    else
+        summary.CapacityDisplay = tostring(summary.Capacity)
+    end
+
+    if UpgradeService.Monetization then
+        summary.Gamepasses = {}
+        for key, value in pairs(UpgradeService.Monetization.GetOwnedPasses(player)) do
+            if value then
+                summary.Gamepasses[key] = true
+            end
+        end
+    end
+
+    local boosts = SessionService.GetBoosts(player)
+    local boostSummary = {}
+    local now = os.time()
+    for key, data in pairs(boosts) do
+        boostSummary[key] = {
+            Multiplier = data.Multiplier,
+            ExpiresIn = data.Expires and math.max(0, data.Expires - now) or nil
+        }
+    end
+    summary.ActiveBoosts = boostSummary
+
+    return summary
+end
+
+function UpgradeService.HandleUpgrade(player, upgradeType)
+    local session = getSession(player)
+    if not session then
+        return false, "No session"
+    end
+
+    local path = Config.getUpgradePath(upgradeType)
+    if not path then
+        return false, "Invalid upgrade"
+    end
+
+    local currentLevel = session.Data[upgradeType .. "Level"]
+    local nextTier = path[currentLevel + 1]
+    if not nextTier then
+        return false, "Maxed"
+    end
+
+    local cost = nextTier.Cost
+    if session.Data.Energy < cost then
+        return false, string.format("Need %d Energy", cost)
+    end
+
+    SessionService.AdjustEnergy(player, -cost)
+    SessionService.RecordUpgrade(player, upgradeType, currentLevel + 1)
+
+    if upgradeType == "Speed" then
+        task.defer(applyWalkSpeed, player)
+    end
+
+    return true, string.format("%s upgraded to level %d", upgradeType, currentLevel + 1)
+end
+
+function UpgradeService.HandleZoneUnlock(player)
+    local session = getSession(player)
+    if not session then
+        return false, "No session"
+    end
+
+    local nextIndex = session.Data.ZoneLevel + 1
+    local zone = Config.getZone(nextIndex)
+    if not zone then
+        return false, "No more zones"
+    end
+
+    local cost = zone.UnlockCost
+    if session.Data.Energy < cost then
+        return false, string.format("Need %d Energy", cost)
+    end
+
+    SessionService.AdjustEnergy(player, -cost)
+    SessionService.RecordZoneUnlock(player, nextIndex)
+
+    return true, string.format("Unlocked %s", zone.Name)
+end
+
+function UpgradeService.HandleRebirth(player)
+    local session = getSession(player)
+    if not session then
+        return false, "No session"
+    end
+
+    if session.Data.ZoneLevel < #Config.Zones then
+        return false, "Unlock all zones first"
+    end
+
+    local cost = Config.getRebirthCost(session.Data.Rebirths)
+    if session.Data.Energy < cost then
+        return false, string.format("Need %d Energy", cost)
+    end
+
+    SessionService.AdjustEnergy(player, -cost)
+    SessionService.RecordRebirth(player)
+
+    task.defer(applyWalkSpeed, player)
+
+    return true, "Rebirth complete!"
+end
+
+function UpgradeService.ApplyCharacterScaling(player)
+    task.defer(applyWalkSpeed, player)
+end
+
+return UpgradeService

--- a/src/StarterPlayer/StarterPlayerScripts/ClientController.client.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/ClientController.client.lua
@@ -1,0 +1,465 @@
+local Players = game:GetService("Players")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local TweenService = game:GetService("TweenService")
+
+local player = Players.LocalPlayer
+local Config = require(ReplicatedStorage:WaitForChild("Shared"):WaitForChild("Config"))
+
+local remotesFolder = ReplicatedStorage:WaitForChild("Remotes")
+local eventsFolder = remotesFolder:WaitForChild("Events")
+
+local remotes = {
+    StateUpdate = eventsFolder:WaitForChild("StateUpdate"),
+    Notify = eventsFolder:WaitForChild("Notify"),
+    ActionRequest = eventsFolder:WaitForChild("ActionRequest"),
+    PurchaseRequest = eventsFolder:WaitForChild("PurchaseRequest"),
+    Tutorial = eventsFolder:WaitForChild("Tutorial")
+}
+
+local screenGui = Instance.new("ScreenGui")
+screenGui.Name = "CrystalRushUI"
+screenGui.ResetOnSpawn = false
+screenGui.Parent = player:WaitForChild("PlayerGui")
+
+local fontMain = Enum.Font.Gotham
+local fontBold = Enum.Font.GothamBold
+
+local function createShadow(frame)
+    local shadow = Instance.new("ImageLabel")
+    shadow.Name = "Shadow"
+    shadow.Image = "rbxassetid://1316045217"
+    shadow.ImageTransparency = 0.6
+    shadow.BackgroundTransparency = 1
+    shadow.Size = UDim2.new(1, 12, 1, 12)
+    shadow.Position = UDim2.new(0, -6, 0, -6)
+    shadow.ScaleType = Enum.ScaleType.Slice
+    shadow.SliceCenter = Rect.new(10, 10, 118, 118)
+    shadow.ZIndex = frame.ZIndex - 1
+    shadow.Parent = frame
+end
+
+local function createLabel(parent, text, size, position, bold)
+    local label = Instance.new("TextLabel")
+    label.BackgroundTransparency = 1
+    label.Text = text
+    label.Font = bold and fontBold or fontMain
+    label.TextColor3 = Color3.fromRGB(240, 244, 255)
+    label.TextScaled = true
+    label.Size = size
+    label.Position = position
+    label.Parent = parent
+    return label
+end
+
+local mainPanel = Instance.new("Frame")
+mainPanel.Name = "StatsPanel"
+mainPanel.Size = UDim2.new(0, 280, 0, 170)
+mainPanel.Position = UDim2.new(0, 20, 0, 20)
+mainPanel.BackgroundColor3 = Color3.fromRGB(32, 41, 69)
+mainPanel.BorderSizePixel = 0
+mainPanel.ZIndex = 3
+mainPanel.Parent = screenGui
+createShadow(mainPanel)
+
+local titleLabel = createLabel(mainPanel, Config.GameName, UDim2.new(1, -20, 0, 28), UDim2.new(0, 10, 0, 8), true)
+titleLabel.TextXAlignment = Enum.TextXAlignment.Left
+titleLabel.TextColor3 = Color3.fromRGB(255, 229, 115)
+
+local energyLabel = createLabel(mainPanel, "Energy: 0", UDim2.new(1, -20, 0, 26), UDim2.new(0, 10, 0, 50), true)
+energyLabel.TextXAlignment = Enum.TextXAlignment.Left
+
+local inventoryLabel = createLabel(mainPanel, "Inventory: 0 / 0", UDim2.new(1, -20, 0, 22), UDim2.new(0, 10, 0, 80), false)
+inventoryLabel.TextXAlignment = Enum.TextXAlignment.Left
+
+local multiplierLabel = createLabel(mainPanel, "Multiplier: 1x", UDim2.new(1, -20, 0, 22), UDim2.new(0, 10, 0, 105), false)
+multiplierLabel.TextXAlignment = Enum.TextXAlignment.Left
+
+local zoneLabel = createLabel(mainPanel, "Zone: 1", UDim2.new(0.5, -10, 0, 22), UDim2.new(0, 10, 0, 132), false)
+zoneLabel.TextXAlignment = Enum.TextXAlignment.Left
+
+local rebirthLabel = createLabel(mainPanel, "Rebirths: 0", UDim2.new(0.5, -10, 0, 22), UDim2.new(0.5, 0, 0, 132), false)
+rebirthLabel.TextXAlignment = Enum.TextXAlignment.Left
+
+local boostLabel = createLabel(mainPanel, "Boosts: None", UDim2.new(1, -20, 0, 22), UDim2.new(0, 10, 0, 152), false)
+boostLabel.TextXAlignment = Enum.TextXAlignment.Left
+
+local upgradesPanel = Instance.new("Frame")
+upgradesPanel.Name = "UpgradesPanel"
+upgradesPanel.Size = UDim2.new(0, 260, 0, 280)
+upgradesPanel.Position = UDim2.new(0, 20, 0, 210)
+upgradesPanel.BackgroundColor3 = Color3.fromRGB(28, 32, 52)
+upgradesPanel.BorderSizePixel = 0
+upgradesPanel.ZIndex = 3
+upgradesPanel.Parent = screenGui
+createShadow(upgradesPanel)
+
+local upgradesLayout = Instance.new("UIListLayout")
+upgradesLayout.Parent = upgradesPanel
+upgradesLayout.Padding = UDim.new(0, 8)
+upgradesLayout.HorizontalAlignment = Enum.HorizontalAlignment.Center
+upgradesLayout.VerticalAlignment = Enum.VerticalAlignment.Top
+upgradesLayout.SortOrder = Enum.SortOrder.LayoutOrder
+
+local function createActionButton(parent, text, action)
+    local button = Instance.new("TextButton")
+    button.Size = UDim2.new(1, -20, 0, 48)
+    button.Text = text
+    button.Font = fontBold
+    button.TextScaled = true
+    button.BackgroundColor3 = Color3.fromRGB(72, 120, 212)
+    button.TextColor3 = Color3.fromRGB(255, 255, 255)
+    button.BorderSizePixel = 0
+    button.AutoButtonColor = true
+    button.Parent = parent
+    button.LayoutOrder = #parent:GetChildren()
+
+    button.MouseButton1Click:Connect(function()
+        remotes.ActionRequest:FireServer(action)
+    end)
+
+    return button
+end
+
+local buttons = {
+    Capacity = createActionButton(upgradesPanel, "Upgrade Backpack", "UpgradeCapacity"),
+    Speed = createActionButton(upgradesPanel, "Upgrade Speed", "UpgradeSpeed"),
+    Converter = createActionButton(upgradesPanel, "Upgrade Converter", "UpgradeConverter"),
+    UnlockZone = createActionButton(upgradesPanel, "Unlock Next Zone", "UnlockZone"),
+    Rebirth = createActionButton(upgradesPanel, "Rebirth", "Rebirth")
+}
+
+local shopToggle = Instance.new("TextButton")
+shopToggle.Name = "ShopToggle"
+shopToggle.Size = UDim2.new(0, 180, 0, 44)
+shopToggle.Position = UDim2.new(1, -200, 0, 20)
+shopToggle.AnchorPoint = Vector2.new(0, 0)
+shopToggle.BackgroundColor3 = Color3.fromRGB(36, 45, 74)
+shopToggle.Text = "Open Crystal Shop"
+shopToggle.TextScaled = true
+shopToggle.Font = fontBold
+shopToggle.TextColor3 = Color3.fromRGB(255, 255, 255)
+shopToggle.Parent = screenGui
+createShadow(shopToggle)
+
+local shopFrame = Instance.new("Frame")
+shopFrame.Name = "ShopFrame"
+shopFrame.Size = UDim2.new(0, 420, 0, 420)
+shopFrame.Position = UDim2.new(1, -440, 0, 80)
+shopFrame.BackgroundColor3 = Color3.fromRGB(23, 27, 46)
+shopFrame.BorderSizePixel = 0
+shopFrame.Visible = false
+shopFrame.ZIndex = 5
+shopFrame.Parent = screenGui
+createShadow(shopFrame)
+
+local shopClose = Instance.new("TextButton")
+shopClose.Size = UDim2.new(0, 28, 0, 28)
+shopClose.Position = UDim2.new(1, -36, 0, 10)
+shopClose.BackgroundTransparency = 1
+shopClose.Text = "✕"
+shopClose.Font = fontBold
+shopClose.TextColor3 = Color3.fromRGB(255, 255, 255)
+shopClose.Parent = shopFrame
+
+local shopTitle = createLabel(shopFrame, "Crystal Shop", UDim2.new(1, -20, 0, 32), UDim2.new(0, 10, 0, 10), true)
+shopTitle.TextXAlignment = Enum.TextXAlignment.Left
+
+local shopScroll = Instance.new("ScrollingFrame")
+shopScroll.Size = UDim2.new(1, -20, 1, -60)
+shopScroll.Position = UDim2.new(0, 10, 0, 50)
+shopScroll.BackgroundTransparency = 1
+shopScroll.BorderSizePixel = 0
+shopScroll.CanvasSize = UDim2.new(0, 0, 0, 0)
+shopScroll.ScrollBarThickness = 6
+shopScroll.Parent = shopFrame
+
+local shopLayout = Instance.new("UIListLayout")
+shopLayout.Parent = shopScroll
+shopLayout.Padding = UDim.new(0, 10)
+shopLayout.SortOrder = Enum.SortOrder.LayoutOrder
+
+local notificationFrame = Instance.new("Frame")
+notificationFrame.Name = "Notification"
+notificationFrame.Size = UDim2.new(0, 420, 0, 36)
+notificationFrame.Position = UDim2.new(0.5, -210, 0, 24)
+notificationFrame.BackgroundColor3 = Color3.fromRGB(47, 60, 102)
+notificationFrame.BackgroundTransparency = 0.2
+notificationFrame.Visible = false
+notificationFrame.ZIndex = 10
+notificationFrame.Parent = screenGui
+createShadow(notificationFrame)
+
+local notificationLabel = createLabel(notificationFrame, "", UDim2.new(1, -20, 1, 0), UDim2.new(0, 10, 0, 0), true)
+notificationLabel.TextXAlignment = Enum.TextXAlignment.Left
+
+local tutorialFrame = Instance.new("Frame")
+tutorialFrame.Name = "TutorialFrame"
+tutorialFrame.Size = UDim2.new(0, 500, 0, 60)
+tutorialFrame.Position = UDim2.new(0.5, -250, 1, -140)
+tutorialFrame.BackgroundColor3 = Color3.fromRGB(38, 46, 80)
+tutorialFrame.Visible = false
+tutorialFrame.ZIndex = 8
+tutorialFrame.Parent = screenGui
+createShadow(tutorialFrame)
+
+local tutorialLabel = createLabel(tutorialFrame, "", UDim2.new(1, -20, 1, -10), UDim2.new(0, 10, 0, 5), false)
+tutorialLabel.TextWrapped = true
+
+tutorialLabel.TextColor3 = Color3.fromRGB(255, 255, 255)
+
+local currentState
+
+local function formatNumber(num)
+    if num >= 1e6 then
+        return string.format("%.1fm", num / 1e6)
+    elseif num >= 1e3 then
+        return string.format("%.1fk", num / 1e3)
+    else
+        return tostring(num)
+    end
+end
+
+local function setButtonState(button, enabled, text)
+    button.Text = text
+    if enabled then
+        button.BackgroundColor3 = Color3.fromRGB(72, 120, 212)
+        button.AutoButtonColor = true
+    else
+        button.BackgroundColor3 = Color3.fromRGB(70, 70, 70)
+        button.AutoButtonColor = false
+    end
+end
+
+local function rebuildShop()
+    shopScroll:ClearAllChildren()
+    shopLayout.Parent = shopScroll
+
+    local entryIndex = 0
+
+    local function createEntry(title, subtitle, priceText, purchaseData, owned)
+        entryIndex += 1
+        local entry = Instance.new("Frame")
+        entry.Size = UDim2.new(1, -4, 0, 90)
+        entry.BackgroundColor3 = Color3.fromRGB(33, 40, 65)
+        entry.BorderSizePixel = 0
+        entry.LayoutOrder = entryIndex
+        entry.Parent = shopScroll
+        entry.ZIndex = 6
+
+        local entryTitle = createLabel(entry, title, UDim2.new(1, -20, 0, 28), UDim2.new(0, 10, 0, 8), true)
+        entryTitle.TextXAlignment = Enum.TextXAlignment.Left
+        entryTitle.ZIndex = 7
+
+        local entrySubtitle = createLabel(entry, subtitle, UDim2.new(1, -20, 0, 22), UDim2.new(0, 10, 0, 38), false)
+        entrySubtitle.TextXAlignment = Enum.TextXAlignment.Left
+        entrySubtitle.TextColor3 = Color3.fromRGB(194, 206, 255)
+        entrySubtitle.ZIndex = 7
+
+        local button = Instance.new("TextButton")
+        button.Size = UDim2.new(0, 140, 0, 32)
+        button.Position = UDim2.new(1, -150, 1, -42)
+        button.AnchorPoint = Vector2.new(0, 0)
+        button.BackgroundColor3 = Color3.fromRGB(76, 151, 255)
+        button.TextColor3 = Color3.fromRGB(255, 255, 255)
+        button.Font = fontBold
+        button.TextScaled = true
+        button.Text = priceText
+        button.Parent = entry
+        button.ZIndex = 7
+
+        if owned then
+            button.Text = "Owned"
+            button.AutoButtonColor = false
+            button.BackgroundColor3 = Color3.fromRGB(80, 80, 80)
+        elseif purchaseData then
+            button.MouseButton1Click:Connect(function()
+                remotes.PurchaseRequest:FireServer(purchaseData)
+            end)
+        else
+            button.Text = "Coming Soon"
+            button.AutoButtonColor = false
+            button.BackgroundColor3 = Color3.fromRGB(80, 80, 80)
+        end
+    end
+
+    local passOrder = {"VIP", "Speed", "InfiniteStorage", "LuckyAura", "AutoCollector"}
+    for _, key in ipairs(passOrder) do
+        local info = Config.Gamepasses[key]
+        if info then
+            local owned = currentState and currentState.Gamepasses and currentState.Gamepasses[key]
+            local priceText = owned and "Owned" or string.format("R$ %d", info.Price)
+            local subtitle = info.Benefit
+            local purchaseData = info.Id ~= 0 and { Type = "Gamepass", Key = key } or nil
+            if info.Id == 0 then
+                priceText = string.format("Set ID • R$ %d", info.Price)
+            end
+            createEntry(info.Name, subtitle, priceText, purchaseData, owned)
+        end
+    end
+
+    for _, product in ipairs(Config.DeveloperProducts.EnergyPacks) do
+        local priceText = string.format("R$ %d", product.Price)
+        local subtitle = string.format("+%s Energy", formatNumber(product.Amount))
+        local purchaseData = product.Id ~= 0 and { Type = "Product", Key = product.Key } or nil
+        if product.Id == 0 then
+            priceText = string.format("Set ID • R$ %d", product.Price)
+        end
+        createEntry(product.Name, subtitle, priceText, purchaseData, false)
+    end
+
+    for _, boost in ipairs(Config.DeveloperProducts.Boosts) do
+        local priceText = string.format("R$ %d", boost.Price)
+        local subtitle = string.format("%d min %dx Converter", math.floor(boost.Duration / 60), boost.Multiplier)
+        local purchaseData = boost.Id ~= 0 and { Type = "Product", Key = boost.Key } or nil
+        if boost.Id == 0 then
+            priceText = string.format("Set ID • R$ %d", boost.Price)
+        end
+        createEntry(boost.Name, subtitle, priceText, purchaseData, false)
+    end
+
+    shopScroll.CanvasSize = UDim2.new(0, 0, 0, shopLayout.AbsoluteContentSize.Y)
+end
+
+local function updateUI()
+    if not currentState then
+        return
+    end
+
+    local energyValue = currentState.Energy or 0
+    local inventoryValue = currentState.Inventory or 0
+    local multiplierValue = currentState.ConverterMultiplier or 1
+    local zoneValue = currentState.ZoneLevel or 1
+    local rebirthValue = currentState.Rebirths or 0
+
+    energyLabel.Text = string.format("Energy: %s", formatNumber(energyValue))
+    local capacityText = currentState.CapacityDisplay or tostring(currentState.Capacity or 0)
+    inventoryLabel.Text = string.format("Inventory: %s / %s", formatNumber(inventoryValue), capacityText)
+    multiplierLabel.Text = string.format("Multiplier: %.2fx", multiplierValue)
+    zoneLabel.Text = string.format("Zone: %d", zoneValue)
+    rebirthLabel.Text = string.format("Rebirths: %d", rebirthValue)
+
+    if currentState.ActiveBoosts then
+        local boostStrings = {}
+        for key, data in pairs(currentState.ActiveBoosts) do
+            local remaining = data.ExpiresIn and math.max(0, math.floor(data.ExpiresIn)) or nil
+            local text = string.format("%s %dx", key, data.Multiplier or 1)
+            if remaining then
+                text ..= string.format(" (%ds)", remaining)
+            end
+            table.insert(boostStrings, text)
+        end
+        if #boostStrings > 0 then
+            boostLabel.Text = "Boosts: " .. table.concat(boostStrings, ", ")
+        else
+            boostLabel.Text = "Boosts: None"
+        end
+    else
+        boostLabel.Text = "Boosts: None"
+    end
+
+    if currentState.CapacityNextCost then
+        setButtonState(buttons.Capacity, true, string.format("Upgrade Backpack\nCost: %s", formatNumber(currentState.CapacityNextCost)))
+    else
+        setButtonState(buttons.Capacity, false, "Backpack Maxed")
+    end
+
+    if currentState.SpeedNextCost then
+        setButtonState(buttons.Speed, true, string.format("Upgrade Speed\nCost: %s", formatNumber(currentState.SpeedNextCost)))
+    else
+        setButtonState(buttons.Speed, false, "Speed Maxed")
+    end
+
+    if currentState.ConverterNextCost then
+        setButtonState(buttons.Converter, true, string.format("Upgrade Converter\nCost: %s", formatNumber(currentState.ConverterNextCost)))
+    else
+        setButtonState(buttons.Converter, false, "Converter Maxed")
+    end
+
+    if currentState.NextZoneCost then
+        setButtonState(buttons.UnlockZone, true, string.format("Unlock Next Zone\nCost: %s", formatNumber(currentState.NextZoneCost)))
+    else
+        setButtonState(buttons.UnlockZone, false, "All Zones Unlocked")
+    end
+
+    local maxZones = #Config.Zones
+    if zoneValue >= maxZones then
+        setButtonState(buttons.Rebirth, true, string.format("Rebirth\nCost: %s", formatNumber(currentState.RebirthCost or 0)))
+    else
+        setButtonState(buttons.Rebirth, false, "Unlock all zones first")
+    end
+
+    rebuildShop()
+end
+
+local notificationTween
+local function showNotification(text, color)
+    notificationLabel.Text = text
+    notificationFrame.BackgroundColor3 = color or Color3.fromRGB(47, 60, 102)
+    notificationFrame.Visible = true
+    notificationFrame.BackgroundTransparency = 0.2
+
+    if notificationTween then
+        notificationTween:Cancel()
+    end
+
+    notificationTween = TweenService:Create(notificationFrame, TweenInfo.new(0.5), { BackgroundTransparency = 0.2 })
+    notificationTween:Play()
+
+    task.delay(3, function()
+        if notificationFrame.Visible then
+            local fade = TweenService:Create(notificationFrame, TweenInfo.new(0.4), { BackgroundTransparency = 1 })
+            fade.Completed:Connect(function()
+                notificationFrame.Visible = false
+                notificationFrame.BackgroundTransparency = 0.2
+            end)
+            fade:Play()
+        end
+    end)
+end
+
+local function showTutorial(text)
+    tutorialLabel.Text = text
+    tutorialFrame.Visible = true
+    tutorialFrame.BackgroundTransparency = 0.05
+
+    local fadeIn = TweenService:Create(tutorialFrame, TweenInfo.new(0.3), { BackgroundTransparency = 0.05 })
+    fadeIn:Play()
+
+    task.delay(6, function()
+        local fadeOut = TweenService:Create(tutorialFrame, TweenInfo.new(0.4), { BackgroundTransparency = 1 })
+        fadeOut.Completed:Connect(function()
+            tutorialFrame.Visible = false
+            tutorialFrame.BackgroundTransparency = 0.05
+        end)
+        fadeOut:Play()
+    end)
+end
+
+remotes.StateUpdate.OnClientEvent:Connect(function(state)
+    currentState = state
+    updateUI()
+end)
+
+remotes.Notify.OnClientEvent:Connect(function(message)
+    showNotification(message)
+end)
+
+remotes.Tutorial.OnClientEvent:Connect(function(message)
+    showTutorial(message)
+end)
+
+shopToggle.MouseButton1Click:Connect(function()
+    shopFrame.Visible = not shopFrame.Visible
+    shopToggle.Text = shopFrame.Visible and "Close Crystal Shop" or "Open Crystal Shop"
+    if shopFrame.Visible then
+        rebuildShop()
+    end
+end)
+
+shopClose.MouseButton1Click:Connect(function()
+    shopFrame.Visible = false
+    shopToggle.Text = "Open Crystal Shop"
+end)
+
+-- Request an initial state if the server hasn't sent one yet
+remotes.ActionRequest:FireServer("__REQUEST_STATE__")


### PR DESCRIPTION
## Summary
- configure the Crystal Rush Tycoon experience including zones, upgrades, gamepasses, developer products, and tutorial copy
- implement server systems for map generation, orb spawning, player data saving, monetization hooks, and progression handling
- add the client HUD, upgrade controls, and shop UI that reacts to live state updates and purchase requests

## Testing
- not run (Roblox scripts)

------
https://chatgpt.com/codex/tasks/task_e_68cd94730630833187fabb65ed23506d