### PR TITLE
Implement Crystal Rush systems and monetization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,61 @@
+# Crystal Rush
+
+Crystal Rush is a fast-paced shard collecting adventure built for Roblox. Players sprint between procedurally generated crystal zones, scoop up energy orbs, and return to base to convert them into spendable Energy. Use Energy to upgrade backpack capacity, speed, converter multiplier, unlock new biomes, and rebirth for permanent multipliers.
+
+## Core Features
+
+- **Dynamic world building** – The map is generated at runtime with teleport pads, return portals, and orb spawners for every zone.
+- **Intuitive progression loop** – Collect orbs, deposit for Energy, upgrade stats, and unlock harder zones with better shard payouts.
+- **Orb rarity system** – Every zone has a chance to spawn rare shards worth significantly more Energy.
+- **Boost & rebirth support** – Time-limited converter boosts and repeatable rebirth prestige keep progression lively.
+- **Responsive UI** – Live stats, upgrade buttons, tutorial prompts, notifications, and an in-game shop are all rendered entirely with scripts.
+
+## Monetization Hooks
+
+All gamepasses are wired to Roblox `MarketplaceService` IDs and include gameplay effects:
+
+| Pass | ID | Benefit |
+| --- | --- | --- |
+| VIP | 1476014436 | VIP chat tag & color, +10% deposit bonus, access to the VIP Crystal Boutique |
+| Hyper Sprint | 1475776403 | Toggleable +50% walk speed boost |
+| Infinite Storage | 1476396573 | Removes backpack capacity limit |
+| Lucky Aura | 1476674539 | +20% luck to upgrade shards into rare versions |
+| Auto Collector | 1475412430 | Toggleable vacuum that picks up nearby shards |
+
+- The shop UI can prompt both gamepass purchases and developer product sales (energy packs and boosts).
+- VIP owners unlock an Energy-based VIP boutique that grants timed converter boosts.
+- Hyper Sprint and Auto Collector include toggle buttons in the HUD for quick control.
+
+## Controls & Flow
+
+1. Run across the active zone to gather glowing orbs.
+2. Watch your inventory and deposit on the golden pad to bank Energy.
+3. Spend Energy on upgrades or zone unlocks via the left-side HUD buttons.
+4. Rebirth after clearing all zones for permanent multipliers and bonus starting Energy.
+5. Purchase boosts or passes from the Crystal Shop (top right) to accelerate progression.
+
+## Project Structure
+
+The repository is Rojo-friendly and mirrors Roblox services:
+
+```
+src/
+├── ReplicatedStorage
+│   └── Shared
+│       └── Config.lua
+├── ServerScriptService
+│   ├── GameInit.server.lua
+│   └── Modules
+│       ├── ChatEffects.lua
+│       ├── MapBuilder.lua
+│       ├── Monetization.lua
+│       ├── OrbManager.lua
+│       ├── Remotes.lua
+│       ├── SessionService.lua
+│       └── UpgradeService.lua
+└── StarterPlayer
+    └── StarterPlayerScripts
+        └── ClientController.client.lua
+```
+
+Deploy with Rojo or sync directly into Studio and publish to make Crystal Rush playable.

--- a/src/ReplicatedStorage/Shared/Config.lua
+++ b/src/ReplicatedStorage/Shared/Config.lua
@@ -1,6 +1,6 @@
 local Config = {}
 
-Config.GameName = "Crystal Rush Tycoon"
+Config.GameName = "Crystal Rush"
 Config.ZoneSpacing = 220
 Config.ZoneY = 0
 Config.ZoneSize = Vector3.new(140, 1, 140)
@@ -113,39 +113,60 @@ Config.Rebirth = {
 
 Config.Gamepasses = {
     VIP = {
-        Name = "VIP Quantum Membership",
-        Benefit = "Permanent 2x deposit multiplier, golden name tag",
+        Name = "Crystal VIP",
+        Benefit = "+10% Energy, VIP chat tag, exclusive shop",
         Price = 399,
-        Id = 0,
-        MultiplierBonus = 2
+        Id = 1476014436,
+        DepositBonus = 0.1,
+        ChatTag = "VIP",
+        ChatColor = Color3.fromRGB(255, 226, 110)
     },
-    Speed = {
+    HYPER_SPRINT = {
         Name = "Hyper Sprint",
-        Benefit = "+6 WalkSpeed permanently",
+        Benefit = "+50% movement speed toggle",
         Price = 149,
-        Id = 0,
-        ExtraSpeed = 6
+        Id = 1475776403,
+        SpeedMultiplier = 1.5
     },
-    InfiniteStorage = {
+    INFINITE_STORAGE = {
         Name = "Infinite Storage",
         Benefit = "Never run out of backpack space",
         Price = 799,
-        Id = 0
+        Id = 1476396573
     },
-    LuckyAura = {
+    LUCKY_AURA = {
         Name = "Lucky Aura",
-        Benefit = "50% more rare shards whenever you collect",
+        Benefit = "+20% luck for rare shards and pet rolls",
         Price = 249,
-        Id = 0,
-        RareBonus = 0.5
+        Id = 1476674539,
+        LuckBonus = 0.2
     },
-    AutoCollector = {
+    AUTO_COLLECTOR = {
         Name = "Auto Collector Drone",
         Benefit = "Automatically vacuum nearby shards",
         Price = 499,
-        Id = 0,
+        Id = 1475412430,
         Radius = 14,
         Interval = 1.5
+    }
+}
+
+Config.VIPShop = {
+    {
+        Key = "VipBoost10",
+        Name = "VIP Turbo Boost",
+        Description = "x2 converter boost for 10 minutes",
+        Cost = 4500,
+        Multiplier = 2,
+        Duration = 600
+    },
+    {
+        Key = "VipBoost30",
+        Name = "VIP Radiant Surge",
+        Description = "x2.5 converter boost for 30 minutes",
+        Cost = 12500,
+        Multiplier = 2.5,
+        Duration = 1800
     }
 }
 

--- a/src/ServerScriptService/GameInit.server.lua
+++ b/src/ServerScriptService/GameInit.server.lua
@@ -8,9 +8,32 @@ local SessionService = require(script.Parent.Modules.SessionService)
 local Monetization = require(script.Parent.Modules.Monetization)
 local UpgradeService = require(script.Parent.Modules.UpgradeService)
 local OrbManager = require(script.Parent.Modules.OrbManager)
+local ChatEffects = require(script.Parent.Modules.ChatEffects)
 
 local remotes = RemotesModule.get()
 local mapReferences = MapBuilder.build()
+
+local vipItemsByKey = {}
+for _, item in ipairs(Config.VIPShop) do
+    vipItemsByKey[item.Key] = item
+end
+
+local function applyVipStatus(player)
+    local isVip = Monetization.PlayerHasPass(player, "VIP")
+    player:SetAttribute("IsVIP", isVip)
+
+    if isVip then
+        ChatEffects.ApplyVipFormatting(player, Config.Gamepasses.VIP.ChatTag, Config.Gamepasses.VIP.ChatColor)
+    else
+        ChatEffects.ClearVipFormatting(player)
+    end
+end
+
+local function applyOwnedPassPerks(player)
+    applyVipStatus(player)
+    task.defer(UpgradeService.ApplyCharacterScaling, player)
+    task.defer(OrbManager.UpdateAutoCollector, player)
+end
 
 local function createLeaderstats(player)
     local folder = Instance.new("Folder")
@@ -82,11 +105,17 @@ end
 UpgradeService.SetDependencies(remotes, Monetization)
 Monetization.SetStateUpdateCallback(sendState)
 Monetization.OnPassUnlocked(function(player, passKey)
-    if passKey == "Speed" then
+    if passKey == "HYPER_SPRINT" then
+        SessionService.SetSetting(player, "HyperSprint", true)
         task.defer(UpgradeService.ApplyCharacterScaling, player)
+    elseif passKey == "AUTO_COLLECTOR" then
+        SessionService.SetSetting(player, "AutoCollector", true)
+        task.defer(OrbManager.UpdateAutoCollector, player)
     end
 
-    if passKey == "InfiniteStorage" or passKey == "VIP" or passKey == "LuckyAura" then
+    task.defer(applyOwnedPassPerks, player)
+
+    if passKey == "VIP" or passKey == "INFINITE_STORAGE" or passKey == "LUCKY_AURA" or passKey == "HYPER_SPRINT" or passKey == "AUTO_COLLECTOR" then
         task.defer(sendState, player)
     end
 end)
@@ -114,6 +143,10 @@ local function handleDeposit(player)
         return
     end
 
+    if Monetization.PlayerHasPass(player, "VIP") then
+        local bonus = Config.Gamepasses.VIP.DepositBonus or 0
+        amount = math.floor(amount * (1 + bonus))
+    end
     SessionService.SetInventory(player, 0)
     SessionService.AdjustEnergy(player, amount)
     remotes.Notify:FireClient(player, string.format("Deposited for %d Energy", amount))
@@ -187,6 +220,79 @@ end
 mapReferences.DepositPad.Touched:Connect(onDepositTouched)
 bindTeleporters()
 
+local function handleHyperSprintToggle(player, desiredState)
+    if not UpgradeService.CanUseHyperSprint(player) then
+        return false, "Hyper Sprint gamepass required"
+    end
+
+    local current = SessionService.GetSetting(player, "HyperSprint") == true
+    local target
+    if typeof(desiredState) == "boolean" then
+        target = desiredState
+    else
+        target = not current
+    end
+
+    SessionService.SetSetting(player, "HyperSprint", target)
+    UpgradeService.ApplyCharacterScaling(player)
+
+    return true, target and "Hyper Sprint enabled" or "Hyper Sprint disabled"
+end
+
+local function handleAutoCollectorToggle(player, desiredState)
+    if not UpgradeService.CanUseAutoCollector(player) then
+        return false, "Auto Collector gamepass required"
+    end
+
+    local current = SessionService.GetSetting(player, "AutoCollector")
+    current = current == nil and true or current == true
+
+    local target
+    if typeof(desiredState) == "boolean" then
+        target = desiredState
+    else
+        target = not current
+    end
+
+    SessionService.SetSetting(player, "AutoCollector", target)
+    OrbManager.UpdateAutoCollector(player)
+
+    return true, target and "Auto Collector enabled" or "Auto Collector disabled"
+end
+
+local function handleVipShopPurchase(player, payload)
+    if typeof(payload) ~= "table" then
+        return false, "Invalid purchase"
+    end
+
+    local key = payload.Key
+    local item = vipItemsByKey[key]
+    if not item then
+        return false, "Unavailable"
+    end
+
+    if not Monetization.PlayerHasPass(player, "VIP") then
+        return false, "VIP exclusive item"
+    end
+
+    local session = SessionService.GetSession(player)
+    if not session then
+        return false, "No session"
+    end
+
+    if session.Data.Energy < item.Cost then
+        return false, string.format("Need %d Energy", item.Cost)
+    end
+
+    SessionService.AdjustEnergy(player, -item.Cost)
+    if item.Multiplier and item.Duration then
+        local expires = os.time() + item.Duration
+        SessionService.AddBoost(player, item.Key, { Multiplier = item.Multiplier, Expires = expires })
+    end
+
+    return true, string.format("%s activated!", item.Name)
+end
+
 local actionHandlers = {
     UpgradeCapacity = function(player)
         return UpgradeService.HandleUpgrade(player, "Capacity")
@@ -202,6 +308,15 @@ local actionHandlers = {
     end,
     Rebirth = function(player)
         return UpgradeService.HandleRebirth(player)
+    end,
+    ToggleHyperSprint = function(player, desiredState)
+        return handleHyperSprintToggle(player, desiredState)
+    end,
+    ToggleAutoCollector = function(player, desiredState)
+        return handleAutoCollectorToggle(player, desiredState)
+    end,
+    PurchaseVIPItem = function(player, payload)
+        return handleVipShopPurchase(player, payload)
     end,
     __REQUEST_STATE__ = function(player)
         sendState(player)
@@ -251,6 +366,7 @@ local function onPlayerAdded(player)
     Monetization.RegisterPlayer(player)
     Monetization.SyncSession(player)
     OrbManager.RegisterPlayer(player)
+    applyOwnedPassPerks(player)
 
     player.CharacterAdded:Connect(function(character)
         onCharacterAdded(player, character)

--- a/src/ServerScriptService/Modules/ChatEffects.lua
+++ b/src/ServerScriptService/Modules/ChatEffects.lua
@@ -1,0 +1,136 @@
+local Players = game:GetService("Players")
+local ServerScriptService = game:GetService("ServerScriptService")
+local TextChatService = game:GetService("TextChatService")
+
+local ChatEffects = {}
+
+local DEFAULT_COLOR = Color3.fromRGB(255, 226, 110)
+local DEFAULT_TAG = "VIP"
+
+local chatService
+local success, service = pcall(function()
+    local runner = ServerScriptService:FindFirstChild("ChatServiceRunner")
+    if runner then
+        return require(runner:WaitForChild("ChatService"))
+    end
+end)
+
+if success then
+    chatService = service
+end
+
+local vipDataByUserId = {}
+local speakerListenerConnected = false
+
+local function ensureSpeakerListener()
+    if not chatService or speakerListenerConnected then
+        return
+    end
+
+    speakerListenerConnected = true
+    chatService.SpeakerAdded:Connect(function(speakerName)
+        local player = Players:FindFirstChild(speakerName)
+        if not player then
+            for _, candidate in ipairs(Players:GetPlayers()) do
+                if candidate.Name == speakerName then
+                    player = candidate
+                    break
+                end
+            end
+        end
+
+        if player then
+            local info = vipDataByUserId[player.UserId]
+            if info then
+                task.defer(ChatEffects.ApplyVipFormatting, player, info.Tag, info.Color)
+            end
+        end
+    end)
+end
+
+local function colorToHex(color)
+    local r = math.floor(math.clamp(color.R, 0, 1) * 255 + 0.5)
+    local g = math.floor(math.clamp(color.G, 0, 1) * 255 + 0.5)
+    local b = math.floor(math.clamp(color.B, 0, 1) * 255 + 0.5)
+    return string.format("#%02X%02X%02X", r, g, b)
+end
+
+if TextChatService and TextChatService.ChatVersion == Enum.ChatVersion.TextChatService then
+    local previousHandler = TextChatService.OnIncomingMessage
+
+    TextChatService.OnIncomingMessage = function(message)
+        if previousHandler then
+            local result = previousHandler(message)
+            if result then
+                return result
+            end
+        end
+
+        if not message.TextSource then
+            return nil
+        end
+
+        local player = Players:GetPlayerByUserId(message.TextSource.UserId)
+        if not player then
+            return nil
+        end
+
+        local info = vipDataByUserId[player.UserId]
+        if not info then
+            return nil
+        end
+
+        local properties = Instance.new("TextChatMessageProperties")
+        local color = info.Color or DEFAULT_COLOR
+        local hex = colorToHex(color)
+        local tag = info.Tag or DEFAULT_TAG
+
+        properties.PrefixText = string.format("<font color=\"%s\">[%s]</font> %s", hex, tag, message.PrefixText)
+        properties.Text = string.format("<font color=\"%s\">%s</font>", hex, message.Text)
+        return properties
+    end
+end
+
+function ChatEffects.ApplyVipFormatting(player, tag, color)
+    if not player then
+        return
+    end
+
+    ensureSpeakerListener()
+
+    local info = {
+        Tag = tag or DEFAULT_TAG,
+        Color = color or DEFAULT_COLOR
+    }
+    vipDataByUserId[player.UserId] = info
+
+    if chatService then
+        local speaker = chatService:GetSpeaker(player.Name)
+        if speaker then
+            speaker:SetExtraData("Tags", {{ TagText = info.Tag, TagColor = info.Color }})
+            speaker:SetExtraData("ChatColor", info.Color)
+        end
+    end
+end
+
+function ChatEffects.ClearVipFormatting(player)
+    if not player then
+        return
+    end
+
+    vipDataByUserId[player.UserId] = nil
+
+    if chatService then
+        local speaker = chatService:GetSpeaker(player.Name)
+        if speaker then
+            speaker:SetExtraData("Tags", {})
+            speaker:SetExtraData("ChatColor", Color3.fromRGB(255, 255, 255))
+        end
+    end
+end
+
+Players.PlayerRemoving:Connect(function(player)
+    vipDataByUserId[player.UserId] = nil
+end)
+
+return ChatEffects

--- a/src/ServerScriptService/Modules/SessionService.lua
+++ b/src/ServerScriptService/Modules/SessionService.lua
@@ -17,7 +17,10 @@ local DEFAULT_DATA = {
     ConverterLevel = 1,
     ZoneLevel = 1,
     Rebirths = 0,
-    Settings = {},
+    Settings = {
+        HyperSprint = false,
+        AutoCollector = true
+    },
     TutorialStep = 0
 }
 
@@ -37,6 +40,16 @@ end
 
 local function createDefaultData()
     return deepCopy(DEFAULT_DATA)
+end
+
+local function ensureSettings(session)
+    session.Data.Settings = session.Data.Settings or {}
+    if session.Data.Settings.HyperSprint == nil then
+        session.Data.Settings.HyperSprint = false
+    end
+    if session.Data.Settings.AutoCollector == nil then
+        session.Data.Settings.AutoCollector = true
+    end
 end
 
 local function getKey(player)
@@ -92,6 +105,7 @@ function SessionService.CreateSession(player)
         LastDeposit = 0
     }
 
+    ensureSettings(session)
     sessions[player] = session
     return session
 end
@@ -195,6 +209,7 @@ function SessionService.RecordRebirth(player)
     session.Data.ConverterLevel = 1
     session.Data.ZoneLevel = 1
     session.Inventory = 0
+    ensureSettings(session)
 end
 
 function SessionService.AddBoost(player, key, data)
@@ -203,6 +218,30 @@ function SessionService.AddBoost(player, key, data)
         return
     end
     session.Boosts[key] = data
+end
+
+function SessionService.GetSettings(player)
+    local session = sessions[player]
+    if not session then
+        return {}
+    end
+    ensureSettings(session)
+    return session.Data.Settings
+end
+
+function SessionService.GetSetting(player, key)
+    local settings = SessionService.GetSettings(player)
+    return settings[key]
+end
+
+function SessionService.SetSetting(player, key, value)
+    local session = sessions[player]
+    if not session then
+        return
+    end
+
+    ensureSettings(session)
+    session.Data.Settings[key] = value
 end
 
 function SessionService.GetBoosts(player)

--- a/src/ServerScriptService/Modules/UpgradeService.lua
+++ b/src/ServerScriptService/Modules/UpgradeService.lua
@@ -54,7 +54,7 @@ function UpgradeService.GetCapacity(player)
     local stats = Config.getUpgradeStats("Capacity", level)
     local capacity = stats and stats.Capacity or 0
 
-    if UpgradeService.Monetization and UpgradeService.Monetization.PlayerHasPass(player, "InfiniteStorage") then
+    if UpgradeService.Monetization and UpgradeService.Monetization.PlayerHasPass(player, "INFINITE_STORAGE") then
         capacity = math.huge
     end
 
@@ -70,8 +70,11 @@ function UpgradeService.GetWalkSpeed(player)
     local stats = Config.getUpgradeStats("Speed", session.Data.SpeedLevel)
     local speed = stats and stats.WalkSpeed or Config.BaseWalkSpeed
 
-    if UpgradeService.Monetization and UpgradeService.Monetization.PlayerHasPass(player, "Speed") then
-        speed += Config.Gamepasses.Speed.ExtraSpeed
+    if UpgradeService.Monetization and UpgradeService.Monetization.PlayerHasPass(player, "HYPER_SPRINT") then
+        local enabled = SessionService.GetSetting(player, "HyperSprint")
+        if enabled then
+            speed *= Config.Gamepasses.HYPER_SPRINT.SpeedMultiplier
+        end
     end
 
     return speed
@@ -87,10 +90,6 @@ function UpgradeService.GetConverterMultiplier(player)
 
     local stats = Config.getUpgradeStats("Converter", session.Data.ConverterLevel)
     local multiplier = stats and stats.Multiplier or 1
-
-    if UpgradeService.Monetization and UpgradeService.Monetization.PlayerHasPass(player, "VIP") then
-        multiplier *= Config.Gamepasses.VIP.MultiplierBonus
-    end
 
     local boosts = SessionService.GetBoosts(player)
     for key, data in pairs(boosts) do
@@ -145,6 +144,8 @@ function UpgradeService.GetStateSummary(player)
             end
         end
     end
+
+    summary.Settings = SessionService.GetSettings(player)
 
     local boosts = SessionService.GetBoosts(player)
     local boostSummary = {}
@@ -240,6 +241,20 @@ end
 
 function UpgradeService.ApplyCharacterScaling(player)
     task.defer(applyWalkSpeed, player)
+end
+
+function UpgradeService.CanUseHyperSprint(player)
+    if not UpgradeService.Monetization then
+        return false
+    end
+    return UpgradeService.Monetization.PlayerHasPass(player, "HYPER_SPRINT")
+end
+
+function UpgradeService.CanUseAutoCollector(player)
+    if not UpgradeService.Monetization then
+        return false
+    end
+    return UpgradeService.Monetization.PlayerHasPass(player, "AUTO_COLLECTOR")
 end
 
 return UpgradeService

--- a/src/StarterPlayer/StarterPlayerScripts/ClientController.client.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/ClientController.client.lua
@@ -53,7 +53,7 @@ end
 
 local mainPanel = Instance.new("Frame")
 mainPanel.Name = "StatsPanel"
-mainPanel.Size = UDim2.new(0, 280, 0, 170)
+mainPanel.Size = UDim2.new(0, 300, 0, 220)
 mainPanel.Position = UDim2.new(0, 20, 0, 20)
 mainPanel.BackgroundColor3 = Color3.fromRGB(32, 41, 69)
 mainPanel.BorderSizePixel = 0
@@ -83,10 +83,45 @@ rebirthLabel.TextXAlignment = Enum.TextXAlignment.Left
 local boostLabel = createLabel(mainPanel, "Boosts: None", UDim2.new(1, -20, 0, 22), UDim2.new(0, 10, 0, 152), false)
 boostLabel.TextXAlignment = Enum.TextXAlignment.Left
 
+local vipStatusLabel = createLabel(mainPanel, "Status: Adventurer", UDim2.new(1, -20, 0, 22), UDim2.new(0, 10, 0, 176), false)
+vipStatusLabel.TextXAlignment = Enum.TextXAlignment.Left
+vipStatusLabel.TextColor3 = Color3.fromRGB(255, 229, 115)
+
+local abilityContainer = Instance.new("Frame")
+abilityContainer.Name = "AbilityContainer"
+abilityContainer.BackgroundTransparency = 1
+abilityContainer.Size = UDim2.new(1, -20, 0, 36)
+abilityContainer.Position = UDim2.new(0, 10, 1, -46)
+abilityContainer.Parent = mainPanel
+
+local sprintToggleButton = Instance.new("TextButton")
+sprintToggleButton.Name = "SprintToggle"
+sprintToggleButton.Size = UDim2.new(0.5, -6, 1, 0)
+sprintToggleButton.Position = UDim2.new(0, 0, 0, 0)
+sprintToggleButton.BackgroundColor3 = Color3.fromRGB(67, 94, 160)
+sprintToggleButton.TextColor3 = Color3.fromRGB(255, 255, 255)
+sprintToggleButton.BorderSizePixel = 0
+sprintToggleButton.Font = fontBold
+sprintToggleButton.TextScaled = true
+sprintToggleButton.Text = "Hyper Sprint"
+sprintToggleButton.Parent = abilityContainer
+
+local autoToggleButton = Instance.new("TextButton")
+autoToggleButton.Name = "AutoToggle"
+autoToggleButton.Size = UDim2.new(0.5, -6, 1, 0)
+autoToggleButton.Position = UDim2.new(0.5, 6, 0, 0)
+autoToggleButton.BackgroundColor3 = Color3.fromRGB(67, 94, 160)
+autoToggleButton.TextColor3 = Color3.fromRGB(255, 255, 255)
+autoToggleButton.BorderSizePixel = 0
+autoToggleButton.Font = fontBold
+autoToggleButton.TextScaled = true
+autoToggleButton.Text = "Auto Collector"
+autoToggleButton.Parent = abilityContainer
+
 local upgradesPanel = Instance.new("Frame")
 upgradesPanel.Name = "UpgradesPanel"
-upgradesPanel.Size = UDim2.new(0, 260, 0, 280)
-upgradesPanel.Position = UDim2.new(0, 20, 0, 210)
+upgradesPanel.Size = UDim2.new(0, 280, 0, 300)
+upgradesPanel.Position = UDim2.new(0, 20, 0, 260)
 upgradesPanel.BackgroundColor3 = Color3.fromRGB(28, 32, 52)
 upgradesPanel.BorderSizePixel = 0
 upgradesPanel.ZIndex = 3
@@ -230,13 +265,64 @@ local function setButtonState(button, enabled, text)
     end
 end
 
+local function updateAbilityButtons()
+    local passes = currentState and currentState.Gamepasses or {}
+    local settings = currentState and currentState.Settings or {}
+
+    local isVip = passes and passes.VIP
+    if isVip then
+        vipStatusLabel.Text = "Status: Crystal VIP"
+        vipStatusLabel.TextColor3 = Color3.fromRGB(255, 229, 115)
+    else
+        vipStatusLabel.Text = "Status: Adventurer"
+        vipStatusLabel.TextColor3 = Color3.fromRGB(194, 206, 255)
+    end
+
+    local hasSprint = passes and passes.HYPER_SPRINT
+    local sprintEnabled = settings and settings.HyperSprint == true
+    if hasSprint then
+        if sprintEnabled then
+            sprintToggleButton.Text = "Hyper Sprint\n[ON]"
+            sprintToggleButton.BackgroundColor3 = Color3.fromRGB(93, 204, 146)
+        else
+            sprintToggleButton.Text = "Hyper Sprint\n[OFF]"
+            sprintToggleButton.BackgroundColor3 = Color3.fromRGB(67, 94, 160)
+        end
+        sprintToggleButton.AutoButtonColor = true
+    else
+        sprintToggleButton.Text = "Hyper Sprint\nUnlock Gamepass"
+        sprintToggleButton.BackgroundColor3 = Color3.fromRGB(70, 70, 70)
+        sprintToggleButton.AutoButtonColor = true
+    end
+
+    local hasAuto = passes and passes.AUTO_COLLECTOR
+    local autoEnabled = settings and settings.AutoCollector
+    if autoEnabled == nil then
+        autoEnabled = true
+    end
+    if hasAuto then
+        if autoEnabled then
+            autoToggleButton.Text = "Auto Collector\n[ON]"
+            autoToggleButton.BackgroundColor3 = Color3.fromRGB(93, 204, 146)
+        else
+            autoToggleButton.Text = "Auto Collector\n[OFF]"
+            autoToggleButton.BackgroundColor3 = Color3.fromRGB(67, 94, 160)
+        end
+        autoToggleButton.AutoButtonColor = true
+    else
+        autoToggleButton.Text = "Auto Collector\nUnlock Gamepass"
+        autoToggleButton.BackgroundColor3 = Color3.fromRGB(70, 70, 70)
+        autoToggleButton.AutoButtonColor = true
+    end
+end
+
 local function rebuildShop()
     shopScroll:ClearAllChildren()
     shopLayout.Parent = shopScroll
 
     local entryIndex = 0
 
-    local function createEntry(title, subtitle, priceText, purchaseData, owned)
+    local function createEntry(title, subtitle, priceText, purchaseData, owned, customClick, customColor)
         entryIndex += 1
         local entry = Instance.new("Frame")
         entry.Size = UDim2.new(1, -4, 0, 90)
@@ -256,10 +342,10 @@ local function rebuildShop()
         entrySubtitle.ZIndex = 7
 
         local button = Instance.new("TextButton")
-        button.Size = UDim2.new(0, 140, 0, 32)
-        button.Position = UDim2.new(1, -150, 1, -42)
+        button.Size = UDim2.new(0, 160, 0, 32)
+        button.Position = UDim2.new(1, -170, 1, -42)
         button.AnchorPoint = Vector2.new(0, 0)
-        button.BackgroundColor3 = Color3.fromRGB(76, 151, 255)
+        button.BackgroundColor3 = customColor or Color3.fromRGB(76, 151, 255)
         button.TextColor3 = Color3.fromRGB(255, 255, 255)
         button.Font = fontBold
         button.TextScaled = true
@@ -271,6 +357,8 @@ local function rebuildShop()
             button.Text = "Owned"
             button.AutoButtonColor = false
             button.BackgroundColor3 = Color3.fromRGB(80, 80, 80)
+        elseif customClick then
+            button.MouseButton1Click:Connect(customClick)
         elseif purchaseData then
             button.MouseButton1Click:Connect(function()
                 remotes.PurchaseRequest:FireServer(purchaseData)
@@ -282,7 +370,7 @@ local function rebuildShop()
         end
     end
 
-    local passOrder = {"VIP", "Speed", "InfiniteStorage", "LuckyAura", "AutoCollector"}
+    local passOrder = {"VIP", "HYPER_SPRINT", "INFINITE_STORAGE", "LUCKY_AURA", "AUTO_COLLECTOR"}
     for _, key in ipairs(passOrder) do
         local info = Config.Gamepasses[key]
         if info then
@@ -315,6 +403,40 @@ local function rebuildShop()
             priceText = string.format("Set ID • R$ %d", boost.Price)
         end
         createEntry(boost.Name, subtitle, priceText, purchaseData, false)
+    end
+
+    local hasVip = currentState and currentState.Gamepasses and currentState.Gamepasses.VIP
+    if hasVip then
+        for _, item in ipairs(Config.VIPShop) do
+            local priceText = string.format("%s Energy", formatNumber(item.Cost))
+            local subtitle = string.format("%s", item.Description)
+            createEntry(
+                item.Name,
+                subtitle,
+                priceText,
+                nil,
+                false,
+                function()
+                    remotes.ActionRequest:FireServer("PurchaseVIPItem", { Key = item.Key })
+                end,
+                Color3.fromRGB(104, 209, 140)
+            )
+        end
+    else
+        local vipInfo = Config.Gamepasses.VIP
+        local subtitle = "Unlock Crystal VIP to access exclusive boosts"
+        local priceText
+        local purchaseData
+        if vipInfo then
+            priceText = string.format("Unlock VIP • R$ %d", vipInfo.Price)
+            if vipInfo.Id ~= 0 then
+                purchaseData = { Type = "Gamepass", Key = "VIP" }
+            end
+        else
+            priceText = "Unlock VIP"
+        end
+
+        createEntry("VIP Crystal Boutique", subtitle, priceText, purchaseData, false)
     end
 
     shopScroll.CanvasSize = UDim2.new(0, 0, 0, shopLayout.AbsoluteContentSize.Y)
@@ -388,6 +510,7 @@ local function updateUI()
         setButtonState(buttons.Rebirth, false, "Unlock all zones first")
     end
 
+    updateAbilityButtons()
     rebuildShop()
 end
 
@@ -446,6 +569,33 @@ end)
 
 remotes.Tutorial.OnClientEvent:Connect(function(message)
     showTutorial(message)
+end)
+
+sprintToggleButton.MouseButton1Click:Connect(function()
+    local passes = currentState and currentState.Gamepasses or {}
+    if not (passes and passes.HYPER_SPRINT) then
+        remotes.PurchaseRequest:FireServer({ Type = "Gamepass", Key = "HYPER_SPRINT" })
+        return
+    end
+
+    local settings = currentState and currentState.Settings or {}
+    local enabled = settings and settings.HyperSprint == true
+    remotes.ActionRequest:FireServer("ToggleHyperSprint", not enabled)
+end)
+
+autoToggleButton.MouseButton1Click:Connect(function()
+    local passes = currentState and currentState.Gamepasses or {}
+    if not (passes and passes.AUTO_COLLECTOR) then
+        remotes.PurchaseRequest:FireServer({ Type = "Gamepass", Key = "AUTO_COLLECTOR" })
+        return
+    end
+
+    local settings = currentState and currentState.Settings or {}
+    local enabled = settings and settings.AutoCollector
+    if enabled == nil then
+        enabled = true
+    end
+    remotes.ActionRequest:FireServer("ToggleAutoCollector", not enabled)
 end)
 
 shopToggle.MouseButton1Click:Connect(function()


### PR DESCRIPTION
## Summary
- rebrand the experience as Crystal Rush and add concrete gamepass metadata and VIP shop offerings
- add chat VIP formatting, deposit bonuses, hyper sprint and auto collector toggles, and a dedicated VIP boutique purchase flow
- expand the client HUD with pass toggles, shop upgrades, and updated monetization wiring plus new README documentation

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ce111b75688331b8f9ebe5f5468022